### PR TITLE
fix wrong order in creating a relative path

### DIFF
--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -55,7 +55,7 @@ def export_mesh_node(escn_file, export_settings, node, parent_gd_node):
         mesh_node['visible'] = not node.hide
         if skeleton_node is not None:
             mesh_node['skeleton'] = NodePath(
-                skeleton_node.get_path(), mesh_node.get_path())
+                mesh_node.get_path(), skeleton_node.get_path())
         if not physics.has_physics(node) or not physics.is_physics_root(node):
             mesh_node['transform'] = node.matrix_local
         else:

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -269,17 +269,17 @@ class Array(list):
 
 
 class NodePath:
-    """Nodes in scene refers to other nodes or nodes' attribute,
-    for example MeshInstane refers Skeleton. """
-    def __init__(self, referee_path, referrer_path, referrer_attr=''):
-        self.ref_path = os.path.relpath(referee_path, referrer_path)
-        self.attr_name = referrer_attr
+    """Node in scene points to other node or node's attribute,
+    for example, a MeshInstane points to a Skeleton. """
+    def __init__(self, from_here, to_there, attribute_pointed=''):
+        self.relative_path = os.path.relpath(to_there, from_here)
+        self.attribute_name = attribute_pointed
 
     def to_string(self):
         """Serialize a node path"""
         return 'NodePath("{}:{}")'.format(
-            self.ref_path,
-            self.attr_name
+            self.relative_path,
+            self.attribute_name
         )
 
 


### PR DESCRIPTION
In the constructor of ```NodePath``` in structure.py. The parameters given to```os.path.relpath()``` have the wrong order. And the only usage of NodePath also passing the parameter in the wrong order. As the third parameters (referer_attr) is designed to be the attribute of the second parameter(referer), it need to be fixed to make the NodePath constructor easy to use.

Also I find the referer, referee are visually confusing, so any suggestion for better naming the parameters ?