### PR TITLE
change a confusing variable name

### DIFF
--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -73,11 +73,11 @@ class GodotExporter:
             exporter = converters.BLENDER_TYPE_TO_EXPORTER["EMPTY"]
 
         # Perform the export
-        parent_gd_node = exporter(self.escn_file, self.config, node,
-                                  parent_gd_node)
+        exported_node = exporter(self.escn_file, self.config, node,
+                                 parent_gd_node)
 
         for child in node.children:
-            self.export_node(child, parent_gd_node)
+            self.export_node(child, exported_node)
 
         bpy.context.scene.objects.active = prev_node
 


### PR DESCRIPTION
in ```export_node()``` in export_godot.py, the variable returned by the ```exporter()``` function is named as ```parent_gd_node```, however, in that function context, it is the godot node corresponding to the blender object under processing. 
so it is better to be named as ```current_gd_node```, as the exporting of animation data and parented bone would be doing there, this renaming will make it less confusing.