### PR TITLE
fix a crash if ARMATURE not exported while parent_bone relation exported

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -87,11 +87,6 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
         description="Export only objects on the active layers.",
         default=True,
         )
-    export_parent_bone_constraint = BoolProperty(
-        name="Parent Bone",
-        description="Export parent relation to armature bones",
-        default=True,
-        )
     material_search_paths = EnumProperty(
         name="Material Search Paths",
         description="Search for existing godot materials with names that match"

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -72,7 +72,7 @@ class GodotExporter:
             )
             exporter = converters.BLENDER_TYPE_TO_EXPORTER["EMPTY"]
 
-        if (self.config['export_parent_bone_constraint'] and
+        if ("ARMATURE" in self.config['object_types'] and
                 node.parent_bone != ''):
             parent_gd_node = converters.BONE_ATTACHMENT_EXPORTER(
                 self.escn_file,

--- a/tests/scenes/export_blends.py
+++ b/tests/scenes/export_blends.py
@@ -18,7 +18,6 @@ def export_escn(out_file):
         use_active_layers=False,
         use_export_selected=False,
         use_mesh_modifiers=True,
-        export_parent_bone_constraint=True,
         material_search_paths = 'PROJECT_DIR'
     )
 


### PR DESCRIPTION
Add a check for ARMATURE before exporting parent_bone relation. otherwise, program would crash if configuration has ```export_parent_bone_constraint```set to ```true``` but ```ARMATURE``` not included in ```object_types```.