### PR TITLE
Fail to find project on Windows

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -39,6 +39,10 @@ bl_info = {  # pylint: disable=invalid-name
 }
 
 
+class ValidationError(Exception):
+    """An error type for explicitly delivering error messages to user."""
+
+
 class ExportGodot(bpy.types.Operator, ExportHelper):
     """Selection to Godot"""
     bl_idname = "export_godot.escn"
@@ -117,20 +121,24 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
 
     def execute(self, context):
         """Begin the export"""
-        if not self.filepath:
-            raise Exception("filepath not set")
+        try:
+            if not self.filepath:
+                raise Exception("filepath not set")
 
-        keywords = self.as_keywords(ignore=(
-            "axis_forward",
-            "axis_up",
-            "global_scale",
-            "check_existing",
-            "filter_glob",
-            "xna_validate",
-        ))
+            keywords = self.as_keywords(ignore=(
+                "axis_forward",
+                "axis_up",
+                "global_scale",
+                "check_existing",
+                "filter_glob",
+                "xna_validate",
+            ))
 
-        from . import export_godot
-        return export_godot.save(self, context, **keywords)
+            from . import export_godot
+            return export_godot.save(self, context, **keywords)
+        except ValidationError as error:
+            self.report({'ERROR'}, str(error))
+            return {'CANCELLED'}
 
 
 def menu_func(self, context):

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -38,13 +38,18 @@ logging.basicConfig(level=logging.INFO, format="[%(levelname)s]: %(message)s")
 def find_godot_project_dir(export_path):
     """Finds the project.godot file assuming that the export path
     is inside a project (looks for a project.godot file)"""
+    from . import ValidationError
     project_dir = export_path
 
+    # Search up until we get to the top, which is "/" in *nix.
+    # Standard Windows ends up as, e.g., "C:\", and independent of what else is
+    # in the world, we can at least watch for repeats, because that's bad.
+    last = None
     while not os.path.isfile(os.path.join(project_dir, "project.godot")):
         project_dir = os.path.split(project_dir)[0]
-        if project_dir == "/" or len(project_dir) < 3:
-            logging.error("Unable to find godot project file")
-            return None
+        if project_dir == "/" or project_dir == last:
+            raise ValidationError("Unable to find godot project file")
+        last = project_dir
     logging.info("Found godot project directory at %s", project_dir)
     return project_dir
 


### PR DESCRIPTION
The method here should prevent endless loops elsewhere, too. This also includes a ValidationError type for delivering coordinated error messages.