### PR TITLE
Exporting without searching for godot project file

### DIFF
--- a/io_scene_godot/converters/material.py
+++ b/io_scene_godot/converters/material.py
@@ -96,7 +96,7 @@ def find_material(export_settings, material):
     """Searches for an existing Godot material"""
     search_type = export_settings["material_search_paths"]
     if search_type == "PROJECT_DIR":
-        search_dir = export_settings["project_path"]
+        search_dir = export_settings["project_path_func"]()
     elif search_type == "EXPORT_DIR":
         search_dir = export_settings["path"]
     else:

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -26,6 +26,7 @@ http://www.godotengine.org
 
 import os
 import collections
+import functools
 import logging
 import bpy
 
@@ -35,6 +36,7 @@ from . import converters
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s]: %(message)s")
 
 
+@functools.lru_cache(maxsize=1)  # Cache it so we don't search lots of times
 def find_godot_project_dir(export_path):
     """Finds the project.godot file assuming that the export path
     is inside a project (looks for a project.godot file)"""
@@ -176,7 +178,9 @@ class GodotExporter:
         self.scene = bpy.context.scene
         self.config = kwargs
         self.config["path"] = path
-        self.config["project_path"] = find_godot_project_dir(path)
+        self.config["project_path_func"] = functools.partial(
+            find_godot_project_dir, path
+        )
         self.valid_nodes = []
 
         self.escn_file = None


### PR DESCRIPTION
For the past little while, the exporter has only been able to export into directories with a godot.project file somewhere in one of the parent folders. This commit means that if you have the material search path to either "None" or "subfolders" (rather than "project"), then the exporter does not look for the project file.