### PR TITLE
Fixes issue with material search materials now showing on windows

### DIFF
--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -221,10 +221,13 @@ class ExternalResource(FileEntry):
 
     def fix_path(self, export_settings):
         """Makes the resource path relative to the exported file"""
+        # The replace line is because godot always works in linux
+        # style slashes, and python doing relpath uses the one
+        # from the native OS
         self.heading['path'] = os.path.relpath(
             self.heading['path'],
             os.path.dirname(export_settings["path"]),
-        )
+        ).replace('\\', '/')
 
 
 class InternalResource(FileEntry):


### PR DESCRIPTION
On windows, the material search was finding the materials but they weren't showing up in Godot. It turns out this was due to slash direction. Godot always uses linux-style-slashes internally, and so when python used the native OS level slash, godot would fail to find the requested resource.