### PR TITLE
Fix searching of materials in export directory

### DIFF
--- a/io_scene_godot/converters/material.py
+++ b/io_scene_godot/converters/material.py
@@ -98,7 +98,7 @@ def find_material(export_settings, material):
     if search_type == "PROJECT_DIR":
         search_dir = export_settings["project_path_func"]()
     elif search_type == "EXPORT_DIR":
-        search_dir = export_settings["path"]
+        search_dir = os.path.dirname(export_settings["path"])
     else:
         search_dir = None
 


### PR DESCRIPTION
export_settings["path"] does contain the full path including file name, so we need to go one level higher, just like we do when computing imgpath