### PR TITLE
fix export action name

### DIFF
--- a/tests/reference_exports/constraint_external_IK.escn
+++ b/tests/reference_exports/constraint_external_IK.escn
@@ -80,7 +80,7 @@ bones/2/bound_children = []
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Armature"]
 
 root_node = NodePath("..:")
-anims/Action = SubResource(2)
+anims/ArmatureAction = SubResource(2)
 
 [node name="Cylinder" type="MeshInstance" parent="Armature"]
 

--- a/tests/reference_exports/constraint_internal_IK.escn
+++ b/tests/reference_exports/constraint_internal_IK.escn
@@ -62,7 +62,7 @@ bones/2/bound_children = []
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Armature"]
 
 root_node = NodePath("..:")
-anims/Action = SubResource(1)
+anims/ArmatureAction = SubResource(1)
 
 [node name="Cylinder" type="MeshInstance" parent="Armature"]
 


### PR DESCRIPTION
fix some bugs brought by #63 

1. fix type bakeup -> backup
2. give name to baked actions (they default have  name 'Action', if multiple action being baked, they will overwrite each other
3. previously, for object has constraint and no active action, constraint will be baked to an action.  currently change to if the object has no animation data `animation_data`, constraint will be baked to an action