### PR TITLE
[WIP] Fixed makefile for updating reference exports (broken as of #76)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-import: export-blends
 
 update-examples:
 	mkdir -p tests/reference_exports
-	cp tests/godot_project/exports/*.escn tests/reference_exports
+	cp -r tests/godot_project/exports/* tests/reference_exports
 
 compare: export-blends
 	diff -x "*.escn.import" -r tests/godot_project/exports/ tests/reference_exports/


### PR DESCRIPTION
Needs to copy whole directory structure instead of just escn files.

HOWEVER, this PR will also copy the escn.import files, which we don't want. I guess another solution should be found.