### PR TITLE
format generated shader code better

### DIFF
--- a/io_scene_godot/converters/material_node_tree/exporters.py
+++ b/io_scene_godot/converters/material_node_tree/exporters.py
@@ -74,7 +74,10 @@ def traversal_tree_from_socket(shader, root_socket):
             cur_node = next_node
 
         visitor = find_node_visitor(shader, cur_node)
+        shader.append_comment_line("node: {}".format(cur_node.name))
+        shader.append_comment_line("type: {}".format(cur_node.bl_idname))
         visitor(shader, cur_node)
+        shader.append_empty_line()
 
         if stack:
             cur_node = stack.pop()

--- a/io_scene_godot/converters/material_node_tree/shader_functions.py
+++ b/io_scene_godot/converters/material_node_tree/shader_functions.py
@@ -85,7 +85,7 @@ void node_bsdf_principled(vec4 color, float subsurface, vec4 subsurface_color,
     sss_strength_out = subsurface;
     metallic_out = metallic;
     specular_out = pow((IOR - 1.0)/(IOR + 1.0), 2)/0.08;
-    roughness_out = sqrt(roughness);
+    roughness_out = roughness;
     clearcoat_out = clearcoat * (1.0 - transmission);
     clearcoat_gloss_out = 1.0 - clearcoat_roughness;
     anisotropy_out = clamp(anisotropy, 0.0, 1.0);
@@ -147,7 +147,7 @@ void node_bsdf_diffuse(vec4 color, float roughness, out vec3 albedo,
         output_sockets=[
             "albedo",
             "specular",
-            "roughness",
+            "oren_nayar_roughness",
         ]
     ),
 
@@ -156,7 +156,7 @@ void node_bsdf_diffuse(vec4 color, float roughness, out vec3 albedo,
 void node_bsdf_glossy(vec4 color, float roughness, out vec3 albedo,
         out float metallic_out, out float roughness_out){
     albedo = color.rgb;
-    roughness_out = sqrt(roughness);
+    roughness_out = roughness;
     metallic_out = 1.0;
 }
 """,

--- a/tests/reference_exports/material_cycle/material_anistropy.escn
+++ b/tests/reference_exports/material_cycle/material_anistropy.escn
@@ -26,7 +26,7 @@ void node_bsdf_principled(vec4 color, float subsurface, vec4 subsurface_color,
     sss_strength_out = subsurface;
     metallic_out = metallic;
     specular_out = pow((IOR - 1.0)/(IOR + 1.0), 2)/0.08;
-    roughness_out = sqrt(roughness);
+    roughness_out = roughness;
     clearcoat_out = clearcoat * (1.0 - transmission);
     clearcoat_gloss_out = 1.0 - clearcoat_roughness;
     anisotropy_out = clamp(anisotropy, 0.0, 1.0);
@@ -42,49 +42,61 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_PrincipledBSDF_BaseColor;
-	var1_PrincipledBSDF_BaseColor = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var2_PrincipledBSDF_Subsurface;
-	var2_PrincipledBSDF_Subsurface = 0.0;
-	vec4 var3_PrincipledBSDF_SubsurfaceColor;
-	var3_PrincipledBSDF_SubsurfaceColor = vec4(0.699999988079071, 0.10000000149011612, 0.10000000149011612, 1.0);
-	float var4_PrincipledBSDF_Metallic;
-	var4_PrincipledBSDF_Metallic = 1.0;
-	float var5_PrincipledBSDF_Specular;
-	var5_PrincipledBSDF_Specular = 0.5;
-	float var6_PrincipledBSDF_Roughness;
-	var6_PrincipledBSDF_Roughness = 0.12921348214149475;
-	float var7_PrincipledBSDF_Clearcoat;
-	var7_PrincipledBSDF_Clearcoat = 0.0;
-	float var8_PrincipledBSDF_ClearcoatRoughness;
-	var8_PrincipledBSDF_ClearcoatRoughness = 0.029999999329447746;
-	float var9_PrincipledBSDF_Anisotropic;
-	var9_PrincipledBSDF_Anisotropic = 1.0;
-	float var10_PrincipledBSDF_Transmission;
-	var10_PrincipledBSDF_Transmission = 0.0;
-	float var11_PrincipledBSDF_IOR;
-	var11_PrincipledBSDF_IOR = 1.4500000476837158;
-	vec3 var12_PrincipledBSDF_output_albedo;
-	float var13_PrincipledBSDF_output_sss_strength;
-	float var14_PrincipledBSDF_output_metallic;
-	float var15_PrincipledBSDF_output_specular;
-	float var16_PrincipledBSDF_output_roughness;
-	float var17_PrincipledBSDF_output_clearcoat;
-	float var18_PrincipledBSDF_output_clearcoat_gloss;
-	float var19_PrincipledBSDF_output_anisotropy;
-	float var20_PrincipledBSDF_output_transmission;
-	float var21_PrincipledBSDF_output_ior;
-	node_bsdf_principled(var1_PrincipledBSDF_BaseColor, var2_PrincipledBSDF_Subsurface, var3_PrincipledBSDF_SubsurfaceColor, var4_PrincipledBSDF_Metallic, var5_PrincipledBSDF_Specular, var6_PrincipledBSDF_Roughness, var7_PrincipledBSDF_Clearcoat, var8_PrincipledBSDF_ClearcoatRoughness, var9_PrincipledBSDF_Anisotropic, var10_PrincipledBSDF_Transmission, var11_PrincipledBSDF_IOR, var12_PrincipledBSDF_output_albedo, var13_PrincipledBSDF_output_sss_strength, var14_PrincipledBSDF_output_metallic, var15_PrincipledBSDF_output_specular, var16_PrincipledBSDF_output_roughness, var17_PrincipledBSDF_output_clearcoat, var18_PrincipledBSDF_output_clearcoat_gloss, var19_PrincipledBSDF_output_anisotropy, var20_PrincipledBSDF_output_transmission, var21_PrincipledBSDF_output_ior);
+	// node: Tangent
+	// type: ShaderNodeTangent
+	
+	// node: Principled BSDF
+	// type: ShaderNodeBsdfPrincipled
+	vec4 var1_BaseColor;
+	var1_BaseColor = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var2_Subsurface;
+	var2_Subsurface = 0.0;
+	vec4 var3_SubsurfaceColor;
+	var3_SubsurfaceColor = vec4(0.699999988079071, 0.10000000149011612, 0.10000000149011612, 1.0);
+	float var4_Metallic;
+	var4_Metallic = 1.0;
+	float var5_Specular;
+	var5_Specular = 0.5;
+	float var6_Roughness;
+	var6_Roughness = 0.12921348214149475;
+	float var7_Clearcoat;
+	var7_Clearcoat = 0.0;
+	float var8_ClearcoatRoughness;
+	var8_ClearcoatRoughness = 0.029999999329447746;
+	float var9_Anisotropic;
+	var9_Anisotropic = 1.0;
+	float var10_Transmission;
+	var10_Transmission = 0.0;
+	float var11_IOR;
+	var11_IOR = 1.4500000476837158;
+	vec3 var12_out_albedo;
+	float var13_out_sss_strength;
+	float var14_out_metallic;
+	float var15_out_specular;
+	float var16_out_roughness;
+	float var17_out_clearcoat;
+	float var18_out_clearcoat_gloss;
+	float var19_out_anisotropy;
+	float var20_out_transmission;
+	float var21_out_ior;
+	node_bsdf_principled(var1_BaseColor, var2_Subsurface, var3_SubsurfaceColor, var4_Metallic, var5_Specular, var6_Roughness, var7_Clearcoat, var8_ClearcoatRoughness, var9_Anisotropic, var10_Transmission, var11_IOR, var12_out_albedo, var13_out_sss_strength, var14_out_metallic, var15_out_specular, var16_out_roughness, var17_out_clearcoat, var18_out_clearcoat_gloss, var19_out_anisotropy, var20_out_transmission, var21_out_ior);
+	// convert from z-up to y-up
 	TANGENT = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * TANGENT;
+	// convert from world space to view space
 	TANGENT = normalize(INV_CAMERA_MATRIX * vec4(TANGENT, 0.0)).xyz;
-	ALBEDO = var12_PrincipledBSDF_output_albedo;
-	SSS_STRENGTH = var13_PrincipledBSDF_output_sss_strength;
-	SPECULAR = var15_PrincipledBSDF_output_specular;
-	METALLIC = var14_PrincipledBSDF_output_metallic;
-	ROUGHNESS = var16_PrincipledBSDF_output_roughness;
-	CLEARCOAT = var17_PrincipledBSDF_output_clearcoat;
-	CLEARCOAT_GLOSS = var18_PrincipledBSDF_output_clearcoat_gloss;
-	ANISOTROPY = var19_PrincipledBSDF_output_anisotropy;
+	
+	ALBEDO = var12_out_albedo;
+	SSS_STRENGTH = var13_out_sss_strength;
+	SPECULAR = var15_out_specular;
+	METALLIC = var14_out_metallic;
+	ROUGHNESS = var16_out_roughness;
+	CLEARCOAT = var17_out_clearcoat;
+	CLEARCOAT_GLOSS = var18_out_clearcoat_gloss;
+	// transmission usually does not work..
+	// TRANSMISSION = vec3(1.0, 1.0, 1.0) * var20_out_transmission;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
+	ANISOTROPY = var19_out_anisotropy;
 	TANGENT = normalize(cross(cross(TANGENT, NORMAL), NORMAL));
 	BINORMAL = cross(TANGENT, NORMAL);
 }
@@ -141,7 +153,7 @@ void node_bsdf_principled(vec4 color, float subsurface, vec4 subsurface_color,
     sss_strength_out = subsurface;
     metallic_out = metallic;
     specular_out = pow((IOR - 1.0)/(IOR + 1.0), 2)/0.08;
-    roughness_out = sqrt(roughness);
+    roughness_out = roughness;
     clearcoat_out = clearcoat * (1.0 - transmission);
     clearcoat_gloss_out = 1.0 - clearcoat_roughness;
     anisotropy_out = clamp(anisotropy, 0.0, 1.0);
@@ -157,58 +169,72 @@ void vertex() {
 
 
 void fragment() {
-	vec3 var1_TextureCoordinate_Object;
-	var1_TextureCoordinate_Object = VERTEX;
-	mat4 var2_inverted_model_matrix;
-	var2_inverted_model_matrix = inverse(WORLD_MATRIX);
-	mat4 var3_inverted_view_matrix;
-	var3_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var1_TextureCoordinate_Object = (var2_inverted_model_matrix * (var3_inverted_view_matrix * vec4(var1_TextureCoordinate_Object, 1.0))).xyz;
-	var1_TextureCoordinate_Object = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_TextureCoordinate_Object;
-	vec4 var4_PrincipledBSDF_BaseColor;
-	var4_PrincipledBSDF_BaseColor = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var5_PrincipledBSDF_Subsurface;
-	var5_PrincipledBSDF_Subsurface = 0.0;
-	vec4 var6_PrincipledBSDF_SubsurfaceColor;
-	var6_PrincipledBSDF_SubsurfaceColor = vec4(0.699999988079071, 0.10000000149011612, 0.10000000149011612, 1.0);
-	float var7_PrincipledBSDF_Metallic;
-	var7_PrincipledBSDF_Metallic = 1.0;
-	float var8_PrincipledBSDF_Specular;
-	var8_PrincipledBSDF_Specular = 0.5;
-	float var9_PrincipledBSDF_Roughness;
-	var9_PrincipledBSDF_Roughness = 0.12921348214149475;
-	float var10_PrincipledBSDF_Clearcoat;
-	var10_PrincipledBSDF_Clearcoat = 0.0;
-	float var11_PrincipledBSDF_ClearcoatRoughness;
-	var11_PrincipledBSDF_ClearcoatRoughness = 0.029999999329447746;
-	float var12_PrincipledBSDF_Anisotropic;
-	var12_PrincipledBSDF_Anisotropic = 1.0;
-	float var13_PrincipledBSDF_Transmission;
-	var13_PrincipledBSDF_Transmission = 0.0;
-	float var14_PrincipledBSDF_IOR;
-	var14_PrincipledBSDF_IOR = 1.4500000476837158;
-	vec3 var15_PrincipledBSDF_output_albedo;
-	float var16_PrincipledBSDF_output_sss_strength;
-	float var17_PrincipledBSDF_output_metallic;
-	float var18_PrincipledBSDF_output_specular;
-	float var19_PrincipledBSDF_output_roughness;
-	float var20_PrincipledBSDF_output_clearcoat;
-	float var21_PrincipledBSDF_output_clearcoat_gloss;
-	float var22_PrincipledBSDF_output_anisotropy;
-	float var23_PrincipledBSDF_output_transmission;
-	float var24_PrincipledBSDF_output_ior;
-	node_bsdf_principled(var4_PrincipledBSDF_BaseColor, var5_PrincipledBSDF_Subsurface, var6_PrincipledBSDF_SubsurfaceColor, var7_PrincipledBSDF_Metallic, var8_PrincipledBSDF_Specular, var9_PrincipledBSDF_Roughness, var10_PrincipledBSDF_Clearcoat, var11_PrincipledBSDF_ClearcoatRoughness, var12_PrincipledBSDF_Anisotropic, var13_PrincipledBSDF_Transmission, var14_PrincipledBSDF_IOR, var15_PrincipledBSDF_output_albedo, var16_PrincipledBSDF_output_sss_strength, var17_PrincipledBSDF_output_metallic, var18_PrincipledBSDF_output_specular, var19_PrincipledBSDF_output_roughness, var20_PrincipledBSDF_output_clearcoat, var21_PrincipledBSDF_output_clearcoat_gloss, var22_PrincipledBSDF_output_anisotropy, var23_PrincipledBSDF_output_transmission, var24_PrincipledBSDF_output_ior);
-	var1_TextureCoordinate_Object = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var1_TextureCoordinate_Object;
-	var1_TextureCoordinate_Object = normalize(INV_CAMERA_MATRIX * vec4(var1_TextureCoordinate_Object, 0.0)).xyz;
-	ALBEDO = var15_PrincipledBSDF_output_albedo;
-	SSS_STRENGTH = var16_PrincipledBSDF_output_sss_strength;
-	SPECULAR = var18_PrincipledBSDF_output_specular;
-	METALLIC = var17_PrincipledBSDF_output_metallic;
-	ROUGHNESS = var19_PrincipledBSDF_output_roughness;
-	CLEARCOAT = var20_PrincipledBSDF_output_clearcoat;
-	CLEARCOAT_GLOSS = var21_PrincipledBSDF_output_clearcoat_gloss;
-	ANISOTROPY = var22_PrincipledBSDF_output_anisotropy;
-	TANGENT = normalize(cross(cross(var1_TextureCoordinate_Object, NORMAL), NORMAL));
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	mat4 inverted_model_matrix;
+	inverted_model_matrix = inverse(WORLD_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	vec3 var1_Object;
+	var1_Object = VERTEX;
+	// convert from view space to model space
+	var1_Object = (inverted_model_matrix * (inverted_view_matrix * vec4(var1_Object, 1.0))).xyz;
+	// convert from y-up to z-up
+	var1_Object = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_Object;
+	
+	// node: Principled BSDF
+	// type: ShaderNodeBsdfPrincipled
+	vec4 var2_BaseColor;
+	var2_BaseColor = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var3_Subsurface;
+	var3_Subsurface = 0.0;
+	vec4 var4_SubsurfaceColor;
+	var4_SubsurfaceColor = vec4(0.699999988079071, 0.10000000149011612, 0.10000000149011612, 1.0);
+	float var5_Metallic;
+	var5_Metallic = 1.0;
+	float var6_Specular;
+	var6_Specular = 0.5;
+	float var7_Roughness;
+	var7_Roughness = 0.12921348214149475;
+	float var8_Clearcoat;
+	var8_Clearcoat = 0.0;
+	float var9_ClearcoatRoughness;
+	var9_ClearcoatRoughness = 0.029999999329447746;
+	float var10_Anisotropic;
+	var10_Anisotropic = 1.0;
+	float var11_Transmission;
+	var11_Transmission = 0.0;
+	float var12_IOR;
+	var12_IOR = 1.4500000476837158;
+	vec3 var13_out_albedo;
+	float var14_out_sss_strength;
+	float var15_out_metallic;
+	float var16_out_specular;
+	float var17_out_roughness;
+	float var18_out_clearcoat;
+	float var19_out_clearcoat_gloss;
+	float var20_out_anisotropy;
+	float var21_out_transmission;
+	float var22_out_ior;
+	node_bsdf_principled(var2_BaseColor, var3_Subsurface, var4_SubsurfaceColor, var5_Metallic, var6_Specular, var7_Roughness, var8_Clearcoat, var9_ClearcoatRoughness, var10_Anisotropic, var11_Transmission, var12_IOR, var13_out_albedo, var14_out_sss_strength, var15_out_metallic, var16_out_specular, var17_out_roughness, var18_out_clearcoat, var19_out_clearcoat_gloss, var20_out_anisotropy, var21_out_transmission, var22_out_ior);
+	// convert from z-up to y-up
+	var1_Object = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var1_Object;
+	// convert from world space to view space
+	var1_Object = normalize(INV_CAMERA_MATRIX * vec4(var1_Object, 0.0)).xyz;
+	
+	ALBEDO = var13_out_albedo;
+	SSS_STRENGTH = var14_out_sss_strength;
+	SPECULAR = var16_out_specular;
+	METALLIC = var15_out_metallic;
+	ROUGHNESS = var17_out_roughness;
+	CLEARCOAT = var18_out_clearcoat;
+	CLEARCOAT_GLOSS = var19_out_clearcoat_gloss;
+	// transmission usually does not work..
+	// TRANSMISSION = vec3(1.0, 1.0, 1.0) * var21_out_transmission;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
+	ANISOTROPY = var20_out_anisotropy;
+	TANGENT = normalize(cross(cross(var1_Object, NORMAL), NORMAL));
 	BINORMAL = cross(TANGENT, NORMAL);
 }
 "

--- a/tests/reference_exports/material_cycle/material_normal.escn
+++ b/tests/reference_exports/material_cycle/material_normal.escn
@@ -9,7 +9,7 @@
 resource_name = "Shader Nodetree"
 code = "shader_type spatial;
 render_mode blend_mix,depth_draw_always,cull_back,diffuse_burley,specular_schlick_ggx;
-uniform sampler2D uni1_ImageTexturetexture_image : hint_normal;
+uniform sampler2D uni1_Normal_OGLpng : hint_normal;
 
 
 void node_tex_image(vec3 co, sampler2D ima, out vec4 color, out float alpha) {
@@ -43,29 +43,47 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_ImageTexture_Color;
-	float var2_ImageTexture_Alpha;
-	node_tex_image(vec3(UV, 0.0), uni1_ImageTexturetexture_image, var1_ImageTexture_Color, var2_ImageTexture_Alpha);
-	vec3 var3_NormalMap_out_normal;
-	node_normal_map_tangent(1.0, var1_ImageTexture_Color, NORMAL, TANGENT, BINORMAL, var3_NormalMap_out_normal);
-	mat4 var4_inverted_view_matrix;
-	var4_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var3_NormalMap_out_normal = normalize(var4_inverted_view_matrix * vec4(var3_NormalMap_out_normal, 0.0)).xyz;
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_NormalMap_out_normal;
-	vec4 var5_DiffuseBSDF_Color;
-	var5_DiffuseBSDF_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_DiffuseBSDF_Color, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_NormalMap_out_normal;
-	var3_NormalMap_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_NormalMap_out_normal, 0.0)).xyz;
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
-	NORMAL = var3_NormalMap_out_normal;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	
+	// node: Image Texture
+	// type: ShaderNodeTexImage
+	// texture image from node Image Texture
+	vec4 var1_Color;
+	float var2_Alpha;
+	node_tex_image(vec3(UV, 0.0), uni1_Normal_OGLpng, var1_Color, var2_Alpha);
+	
+	// node: Normal Map
+	// type: ShaderNodeNormalMap
+	vec3 var3_out_normal;
+	node_normal_map_tangent(1.0, var1_Color, NORMAL, TANGENT, BINORMAL, var3_out_normal);
+	// convert from view space to world space
+	var3_out_normal = normalize(inverted_view_matrix * vec4(var3_out_normal, 0.0)).xyz;
+	// convert from y-up to z-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_out_normal;
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var4_Color;
+	var4_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var5_Roughness;
+	var5_Roughness = 0.0;
+	vec3 var6_out_albedo;
+	float var7_out_specular;
+	float var8_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var4_Color, var5_Roughness, var6_out_albedo, var7_out_specular, var8_out_oren_nayar_roughness);
+	// convert from z-up to y-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_out_normal;
+	// convert from world space to view space
+	var3_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_out_normal, 0.0)).xyz;
+	
+	ALBEDO = var6_out_albedo;
+	SPECULAR = var7_out_specular;
+	NORMAL = var3_out_normal;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -73,7 +91,7 @@ void fragment() {
 
 resource_name = ""
 shader = SubResource(1)
-shader_param/uni1_ImageTexturetexture_image = ExtResource(1)
+shader_param/uni1_Normal_OGLpng = ExtResource(1)
 
 [sub_resource id=3 type="ArrayMesh"]
 
@@ -130,27 +148,39 @@ void vertex() {
 
 
 void fragment() {
-	vec3 var1_TextureCoordinate_Normal;
-	var1_TextureCoordinate_Normal = NORMAL;
-	mat4 var2_inverted_model_matrix;
-	var2_inverted_model_matrix = inverse(WORLD_MATRIX);
-	mat4 var3_inverted_view_matrix;
-	var3_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var1_TextureCoordinate_Normal = normalize(var2_inverted_model_matrix * (var3_inverted_view_matrix * vec4(var1_TextureCoordinate_Normal, 0.0))).xyz;
-	var1_TextureCoordinate_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_TextureCoordinate_Normal;
-	vec3 var4_Mapping_Vector;
-	node_mapping(var1_TextureCoordinate_Normal, mat4(vec4(0.9770439267158508, -0.033913709223270416, -0.01857101544737816, -0.0), vec4(0.14079418778419495, 0.2036508023738861, -0.021205507218837738, 0.0), vec4(0.15988115966320038, 0.027910366654396057, 0.13216260075569153, -0.0), vec4(-6.83930778503418, 0.23739595711231232, 0.1299971044063568, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var4_Mapping_Vector);
-	vec4 var5_auto_insert_VecToColor;
-	var5_auto_insert_VecToColor = vec4(clamp(var4_Mapping_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_auto_insert_VecToColor, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	mat4 inverted_model_matrix;
+	inverted_model_matrix = inverse(WORLD_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	vec3 var1_Normal;
+	var1_Normal = NORMAL;
+	// convert from view space to model space
+	var1_Normal = normalize(inverted_model_matrix * (inverted_view_matrix * vec4(var1_Normal, 0.0))).xyz;
+	// convert from y-up to z-up
+	var1_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_Normal;
+	
+	// node: Mapping
+	// type: ShaderNodeMapping
+	vec3 var2_Vector;
+	node_mapping(var1_Normal, mat4(vec4(0.9770439267158508, -0.033913709223270416, -0.01857101544737816, -0.0), vec4(0.14079418778419495, 0.2036508023738861, -0.021205507218837738, 0.0), vec4(0.15988115966320038, 0.027910366654396057, 0.13216260075569153, -0.0), vec4(-6.83930778503418, 0.23739595711231232, 0.1299971044063568, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var2_Vector);
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var3_converted_var2_Vector;
+	var3_converted_var2_Vector = vec4(clamp(var2_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
+	float var4_Roughness;
+	var4_Roughness = 0.0;
+	vec3 var5_out_albedo;
+	float var6_out_specular;
+	float var7_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var3_converted_var2_Vector, var4_Roughness, var5_out_albedo, var6_out_specular, var7_out_oren_nayar_roughness);
+	
+	ALBEDO = var5_out_albedo;
+	SPECULAR = var6_out_specular;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -214,27 +244,39 @@ void vertex() {
 
 
 void fragment() {
-	vec3 var1_TextureCoordinate_Normal;
-	var1_TextureCoordinate_Normal = NORMAL;
-	mat4 var2_inverted_model_matrix;
-	var2_inverted_model_matrix = inverse(WORLD_MATRIX);
-	mat4 var3_inverted_view_matrix;
-	var3_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var1_TextureCoordinate_Normal = normalize(var2_inverted_model_matrix * (var3_inverted_view_matrix * vec4(var1_TextureCoordinate_Normal, 0.0))).xyz;
-	var1_TextureCoordinate_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_TextureCoordinate_Normal;
-	vec3 var4_Mapping_Vector;
-	node_mapping(var1_TextureCoordinate_Normal, mat4(vec4(16.43028450012207, 0.0, -2.3676400184631348, 0.0), vec4(0.13027772307395935, 3.894315481185913, 0.9040648937225342, 0.0), vec4(0.13886050879955292, -0.22835084795951843, 0.9636252522468567, 0.0), vec4(0.0, 0.0, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var4_Mapping_Vector);
-	vec4 var5_auto_insert_VecToColor;
-	var5_auto_insert_VecToColor = vec4(clamp(var4_Mapping_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_auto_insert_VecToColor, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	mat4 inverted_model_matrix;
+	inverted_model_matrix = inverse(WORLD_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	vec3 var1_Normal;
+	var1_Normal = NORMAL;
+	// convert from view space to model space
+	var1_Normal = normalize(inverted_model_matrix * (inverted_view_matrix * vec4(var1_Normal, 0.0))).xyz;
+	// convert from y-up to z-up
+	var1_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_Normal;
+	
+	// node: Mapping
+	// type: ShaderNodeMapping
+	vec3 var2_Vector;
+	node_mapping(var1_Normal, mat4(vec4(16.43028450012207, 0.0, -2.3676400184631348, 0.0), vec4(0.13027772307395935, 3.894315481185913, 0.9040648937225342, 0.0), vec4(0.13886050879955292, -0.22835084795951843, 0.9636252522468567, 0.0), vec4(0.0, 0.0, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var2_Vector);
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var3_converted_var2_Vector;
+	var3_converted_var2_Vector = vec4(clamp(var2_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
+	float var4_Roughness;
+	var4_Roughness = 0.0;
+	vec3 var5_out_albedo;
+	float var6_out_specular;
+	float var7_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var3_converted_var2_Vector, var4_Roughness, var5_out_albedo, var6_out_specular, var7_out_oren_nayar_roughness);
+	
+	ALBEDO = var5_out_albedo;
+	SPECULAR = var6_out_specular;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -278,28 +320,40 @@ void vertex() {
 
 
 void fragment() {
-	vec3 var1_TextureCoordinate_Normal;
-	var1_TextureCoordinate_Normal = NORMAL;
-	mat4 var2_inverted_model_matrix;
-	var2_inverted_model_matrix = inverse(WORLD_MATRIX);
-	mat4 var3_inverted_view_matrix;
-	var3_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var1_TextureCoordinate_Normal = normalize(var2_inverted_model_matrix * (var3_inverted_view_matrix * vec4(var1_TextureCoordinate_Normal, 0.0))).xyz;
-	var1_TextureCoordinate_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_TextureCoordinate_Normal;
-	vec3 var4_Mapping_Vector;
-	node_mapping(var1_TextureCoordinate_Normal, mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, -4.371138828673793e-08, 1.0, 0.0), vec4(0.0, -1.0, -4.371138828673793e-08, 0.0), vec4(0.0, 0.0, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var4_Mapping_Vector);
-	var4_Mapping_Vector = normalize(var4_Mapping_Vector);
-	vec4 var5_auto_insert_VecToColor;
-	var5_auto_insert_VecToColor = vec4(clamp(var4_Mapping_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_auto_insert_VecToColor, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	mat4 inverted_model_matrix;
+	inverted_model_matrix = inverse(WORLD_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	vec3 var1_Normal;
+	var1_Normal = NORMAL;
+	// convert from view space to model space
+	var1_Normal = normalize(inverted_model_matrix * (inverted_view_matrix * vec4(var1_Normal, 0.0))).xyz;
+	// convert from y-up to z-up
+	var1_Normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_Normal;
+	
+	// node: Mapping
+	// type: ShaderNodeMapping
+	vec3 var2_Vector;
+	node_mapping(var1_Normal, mat4(vec4(1.0, 0.0, 0.0, 0.0), vec4(0.0, -4.371138828673793e-08, 1.0, 0.0), vec4(0.0, -1.0, -4.371138828673793e-08, 0.0), vec4(0.0, 0.0, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var2_Vector);
+	var2_Vector = normalize(var2_Vector);
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var3_converted_var2_Vector;
+	var3_converted_var2_Vector = vec4(clamp(var2_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
+	float var4_Roughness;
+	var4_Roughness = 0.0;
+	vec3 var5_out_albedo;
+	float var6_out_specular;
+	float var7_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var3_converted_var2_Vector, var4_Roughness, var5_out_albedo, var6_out_specular, var7_out_oren_nayar_roughness);
+	
+	ALBEDO = var5_out_albedo;
+	SPECULAR = var6_out_specular;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -343,27 +397,39 @@ void vertex() {
 
 
 void fragment() {
-	vec3 var1_TextureCoordinate_Object;
-	var1_TextureCoordinate_Object = VERTEX;
-	mat4 var2_inverted_model_matrix;
-	var2_inverted_model_matrix = inverse(WORLD_MATRIX);
-	mat4 var3_inverted_view_matrix;
-	var3_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var1_TextureCoordinate_Object = (var2_inverted_model_matrix * (var3_inverted_view_matrix * vec4(var1_TextureCoordinate_Object, 1.0))).xyz;
-	var1_TextureCoordinate_Object = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_TextureCoordinate_Object;
-	vec3 var4_Mapping_Vector;
-	node_mapping(var1_TextureCoordinate_Object, mat4(vec4(14.399999618530273, 0.0, 0.0, 0.0), vec4(0.0, -4.371138828673793e-08, 1.0, 0.0), vec4(0.0, -1.0, -4.371138828673793e-08, 0.0), vec4(8.80000114440918, -3.999999761581421, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var4_Mapping_Vector);
-	vec4 var5_auto_insert_VecToColor;
-	var5_auto_insert_VecToColor = vec4(clamp(var4_Mapping_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_auto_insert_VecToColor, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	mat4 inverted_model_matrix;
+	inverted_model_matrix = inverse(WORLD_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	vec3 var1_Object;
+	var1_Object = VERTEX;
+	// convert from view space to model space
+	var1_Object = (inverted_model_matrix * (inverted_view_matrix * vec4(var1_Object, 1.0))).xyz;
+	// convert from y-up to z-up
+	var1_Object = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var1_Object;
+	
+	// node: Mapping
+	// type: ShaderNodeMapping
+	vec3 var2_Vector;
+	node_mapping(var1_Object, mat4(vec4(14.399999618530273, 0.0, 0.0, 0.0), vec4(0.0, -4.371138828673793e-08, 1.0, 0.0), vec4(0.0, -1.0, -4.371138828673793e-08, 0.0), vec4(8.80000114440918, -3.999999761581421, 0.0, 1.0)), vec3(0.0, 0.0, 0.0), vec3(1.0, 1.0, 1.0), 0.0, 0.0, var2_Vector);
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var3_converted_var2_Vector;
+	var3_converted_var2_Vector = vec4(clamp(var2_Vector, vec3(0.0, 0.0, 0.0),vec3(1.0, 1.0, 1.0)).xyz, 1.0);
+	float var4_Roughness;
+	var4_Roughness = 0.0;
+	vec3 var5_out_albedo;
+	float var6_out_specular;
+	float var7_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var3_converted_var2_Vector, var4_Roughness, var5_out_albedo, var6_out_specular, var7_out_oren_nayar_roughness);
+	
+	ALBEDO = var5_out_albedo;
+	SPECULAR = var6_out_specular;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -402,7 +468,7 @@ surfaces/0 = {
 resource_name = "Shader Nodetree"
 code = "shader_type spatial;
 render_mode blend_mix,depth_draw_always,cull_back,diffuse_burley,specular_schlick_ggx;
-uniform sampler2D uni1_ImageTexturetexture_image : hint_normal;
+uniform sampler2D uni1_Normal_OGLpng : hint_normal;
 
 
 void node_tex_image(vec3 co, sampler2D ima, out vec4 color, out float alpha) {
@@ -435,28 +501,45 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_ImageTexture_Color;
-	float var2_ImageTexture_Alpha;
-	node_tex_image(vec3(UV, 0.0), uni1_ImageTexturetexture_image, var1_ImageTexture_Color, var2_ImageTexture_Alpha);
-	vec3 var3_NormalMap_out_normal;
-	mat4 var4_inverted_view_matrix;
-	var4_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	node_normal_map_object(8.0, var1_ImageTexture_Color, NORMAL, var4_inverted_view_matrix, WORLD_MATRIX, var3_NormalMap_out_normal);
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_NormalMap_out_normal;
-	vec4 var5_DiffuseBSDF_Color;
-	var5_DiffuseBSDF_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_DiffuseBSDF_Color, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_NormalMap_out_normal;
-	var3_NormalMap_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_NormalMap_out_normal, 0.0)).xyz;
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
-	NORMAL = var3_NormalMap_out_normal;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	
+	// node: Image Texture
+	// type: ShaderNodeTexImage
+	// texture image from node Image Texture
+	vec4 var1_Color;
+	float var2_Alpha;
+	node_tex_image(vec3(UV, 0.0), uni1_Normal_OGLpng, var1_Color, var2_Alpha);
+	
+	// node: Normal Map
+	// type: ShaderNodeNormalMap
+	vec3 var3_out_normal;
+	node_normal_map_object(8.0, var1_Color, NORMAL, inverted_view_matrix, WORLD_MATRIX, var3_out_normal);
+	// convert from y-up to z-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_out_normal;
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var4_Color;
+	var4_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var5_Roughness;
+	var5_Roughness = 0.0;
+	vec3 var6_out_albedo;
+	float var7_out_specular;
+	float var8_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var4_Color, var5_Roughness, var6_out_albedo, var7_out_specular, var8_out_oren_nayar_roughness);
+	// convert from z-up to y-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_out_normal;
+	// convert from world space to view space
+	var3_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_out_normal, 0.0)).xyz;
+	
+	ALBEDO = var6_out_albedo;
+	SPECULAR = var7_out_specular;
+	NORMAL = var3_out_normal;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -464,7 +547,7 @@ void fragment() {
 
 resource_name = ""
 shader = SubResource(15)
-shader_param/uni1_ImageTexturetexture_image = ExtResource(1)
+shader_param/uni1_Normal_OGLpng = ExtResource(1)
 
 [sub_resource id=17 type="ArrayMesh"]
 
@@ -491,7 +574,7 @@ surfaces/0 = {
 resource_name = "Shader Nodetree"
 code = "shader_type spatial;
 render_mode blend_mix,depth_draw_always,cull_back,diffuse_burley,specular_schlick_ggx;
-uniform sampler2D uni1_ImageTexturetexture_image : hint_normal;
+uniform sampler2D uni1_Normal_OGLpng : hint_normal;
 
 
 void node_tex_image(vec3 co, sampler2D ima, out vec4 color, out float alpha) {
@@ -523,28 +606,45 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_ImageTexture_Color;
-	float var2_ImageTexture_Alpha;
-	node_tex_image(vec3(UV, 0.0), uni1_ImageTexturetexture_image, var1_ImageTexture_Color, var2_ImageTexture_Alpha);
-	vec3 var3_NormalMap_out_normal;
-	mat4 var4_inverted_view_matrix;
-	var4_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	node_normal_map_world(8.0, var1_ImageTexture_Color, NORMAL, var4_inverted_view_matrix, var3_NormalMap_out_normal);
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_NormalMap_out_normal;
-	vec4 var5_DiffuseBSDF_Color;
-	var5_DiffuseBSDF_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var6_DiffuseBSDF_Roughness;
-	var6_DiffuseBSDF_Roughness = 0.0;
-	vec3 var7_DiffuseBSDF_output_albedo;
-	float var8_DiffuseBSDF_output_specular;
-	float var9_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var5_DiffuseBSDF_Color, var6_DiffuseBSDF_Roughness, var7_DiffuseBSDF_output_albedo, var8_DiffuseBSDF_output_specular, var9_DiffuseBSDF_output_roughness);
-	var3_NormalMap_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_NormalMap_out_normal;
-	var3_NormalMap_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_NormalMap_out_normal, 0.0)).xyz;
-	ALBEDO = var7_DiffuseBSDF_output_albedo;
-	SPECULAR = var8_DiffuseBSDF_output_specular;
-	ROUGHNESS = var9_DiffuseBSDF_output_roughness;
-	NORMAL = var3_NormalMap_out_normal;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	// node: UV Map
+	// type: ShaderNodeUVMap
+	
+	// node: Image Texture
+	// type: ShaderNodeTexImage
+	// texture image from node Image Texture
+	vec4 var1_Color;
+	float var2_Alpha;
+	node_tex_image(vec3(UV, 0.0), uni1_Normal_OGLpng, var1_Color, var2_Alpha);
+	
+	// node: Normal Map
+	// type: ShaderNodeNormalMap
+	vec3 var3_out_normal;
+	node_normal_map_world(8.0, var1_Color, NORMAL, inverted_view_matrix, var3_out_normal);
+	// convert from y-up to z-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var3_out_normal;
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var4_Color;
+	var4_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var5_Roughness;
+	var5_Roughness = 0.0;
+	vec3 var6_out_albedo;
+	float var7_out_specular;
+	float var8_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var4_Color, var5_Roughness, var6_out_albedo, var7_out_specular, var8_out_oren_nayar_roughness);
+	// convert from z-up to y-up
+	var3_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var3_out_normal;
+	// convert from world space to view space
+	var3_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var3_out_normal, 0.0)).xyz;
+	
+	ALBEDO = var6_out_albedo;
+	SPECULAR = var7_out_specular;
+	NORMAL = var3_out_normal;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -552,7 +652,7 @@ void fragment() {
 
 resource_name = ""
 shader = SubResource(18)
-shader_param/uni1_ImageTexturetexture_image = ExtResource(1)
+shader_param/uni1_Normal_OGLpng = ExtResource(1)
 
 [sub_resource id=20 type="ArrayMesh"]
 
@@ -579,7 +679,7 @@ surfaces/0 = {
 resource_name = "Shader Nodetree"
 code = "shader_type spatial;
 render_mode blend_mix,depth_draw_always,cull_back,diffuse_burley,specular_schlick_ggx;
-uniform sampler2D uni1_ImageTexture001texture_image;
+uniform sampler2D uni1_bumppng;
 
 
 void node_tex_image(vec3 co, sampler2D ima, out vec4 color, out float alpha) {
@@ -635,31 +735,49 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_ImageTexture001_Color;
-	float var2_ImageTexture001_Alpha;
-	node_tex_image(vec3(UV, 0.0), uni1_ImageTexture001texture_image, var1_ImageTexture001_Color, var2_ImageTexture001_Alpha);
-	float var3_auto_insert_RGBtoBW;
-	node_rgb_to_bw(var1_ImageTexture001_Color, var3_auto_insert_RGBtoBW);
-	vec3 var4_Bump_out_normal;
-	node_bump(1.0, 0.10000000149011612, var3_auto_insert_RGBtoBW, NORMAL, VERTEX, 0.0, var4_Bump_out_normal);
-	mat4 var5_inverted_view_matrix;
-	var5_inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
-	var4_Bump_out_normal = normalize(var5_inverted_view_matrix * vec4(var4_Bump_out_normal, 0.0)).xyz;
-	var4_Bump_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var4_Bump_out_normal;
-	vec4 var6_DiffuseBSDF_Color;
-	var6_DiffuseBSDF_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
-	float var7_DiffuseBSDF_Roughness;
-	var7_DiffuseBSDF_Roughness = 0.0;
-	vec3 var8_DiffuseBSDF_output_albedo;
-	float var9_DiffuseBSDF_output_specular;
-	float var10_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var6_DiffuseBSDF_Color, var7_DiffuseBSDF_Roughness, var8_DiffuseBSDF_output_albedo, var9_DiffuseBSDF_output_specular, var10_DiffuseBSDF_output_roughness);
-	var4_Bump_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var4_Bump_out_normal;
-	var4_Bump_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var4_Bump_out_normal, 0.0)).xyz;
-	ALBEDO = var8_DiffuseBSDF_output_albedo;
-	SPECULAR = var9_DiffuseBSDF_output_specular;
-	ROUGHNESS = var10_DiffuseBSDF_output_roughness;
-	NORMAL = var4_Bump_out_normal;
+	mat4 inverted_view_matrix;
+	inverted_view_matrix = inverse(INV_CAMERA_MATRIX);
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	
+	// node: Image Texture.001
+	// type: ShaderNodeTexImage
+	// texture image from node Image Texture.001
+	vec4 var1_Color;
+	float var2_Alpha;
+	node_tex_image(vec3(UV, 0.0), uni1_bumppng, var1_Color, var2_Alpha);
+	
+	// node: Bump
+	// type: ShaderNodeBump
+	float var3_converted_var1_Color;
+	node_rgb_to_bw(var1_Color, var3_converted_var1_Color);
+	vec3 var4_out_normal;
+	node_bump(1.0, 0.10000000149011612, var3_converted_var1_Color, NORMAL, VERTEX, 0.0, var4_out_normal);
+	// convert from view space to world space
+	var4_out_normal = normalize(inverted_view_matrix * vec4(var4_out_normal, 0.0)).xyz;
+	// convert from y-up to z-up
+	var4_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, 1), vec3(0, -1, 0)) * var4_out_normal;
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	vec4 var5_Color;
+	var5_Color = vec4(0.800000011920929, 0.800000011920929, 0.800000011920929, 1.0);
+	float var6_Roughness;
+	var6_Roughness = 0.0;
+	vec3 var7_out_albedo;
+	float var8_out_specular;
+	float var9_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var5_Color, var6_Roughness, var7_out_albedo, var8_out_specular, var9_out_oren_nayar_roughness);
+	// convert from z-up to y-up
+	var4_out_normal = mat3(vec3(1, 0, 0), vec3(0, 0, -1), vec3(0, 1, 0)) * var4_out_normal;
+	// convert from world space to view space
+	var4_out_normal = normalize(INV_CAMERA_MATRIX * vec4(var4_out_normal, 0.0)).xyz;
+	
+	ALBEDO = var7_out_albedo;
+	SPECULAR = var8_out_specular;
+	NORMAL = var4_out_normal;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -667,7 +785,7 @@ void fragment() {
 
 resource_name = ""
 shader = SubResource(21)
-shader_param/uni1_ImageTexture001texture_image = ExtResource(2)
+shader_param/uni1_bumppng = ExtResource(2)
 
 [sub_resource id=23 type="ArrayMesh"]
 

--- a/tests/reference_exports/material_cycle/material_unpack_texture.escn
+++ b/tests/reference_exports/material_cycle/material_unpack_texture.escn
@@ -6,7 +6,7 @@
 resource_name = "Shader Nodetree"
 code = "shader_type spatial;
 render_mode blend_mix,depth_draw_always,cull_back,diffuse_burley,specular_schlick_ggx;
-uniform sampler2D uni1_ImageTexturetexture_image;
+uniform sampler2D uni1_brick_4_diff_1kjpg;
 
 
 void node_tex_image(vec3 co, sampler2D ima, out vec4 color, out float alpha) {
@@ -30,18 +30,29 @@ void vertex() {
 
 
 void fragment() {
-	vec4 var1_ImageTexture_Color;
-	float var2_ImageTexture_Alpha;
-	node_tex_image(vec3(UV, 0.0), uni1_ImageTexturetexture_image, var1_ImageTexture_Color, var2_ImageTexture_Alpha);
-	float var3_DiffuseBSDF_Roughness;
-	var3_DiffuseBSDF_Roughness = 0.0;
-	vec3 var4_DiffuseBSDF_output_albedo;
-	float var5_DiffuseBSDF_output_specular;
-	float var6_DiffuseBSDF_output_roughness;
-	node_bsdf_diffuse(var1_ImageTexture_Color, var3_DiffuseBSDF_Roughness, var4_DiffuseBSDF_output_albedo, var5_DiffuseBSDF_output_specular, var6_DiffuseBSDF_output_roughness);
-	ALBEDO = var4_DiffuseBSDF_output_albedo;
-	SPECULAR = var5_DiffuseBSDF_output_specular;
-	ROUGHNESS = var6_DiffuseBSDF_output_roughness;
+	// node: Texture Coordinate
+	// type: ShaderNodeTexCoord
+	
+	// node: Image Texture
+	// type: ShaderNodeTexImage
+	// texture image from node Image Texture
+	vec4 var1_Color;
+	float var2_Alpha;
+	node_tex_image(vec3(UV, 0.0), uni1_brick_4_diff_1kjpg, var1_Color, var2_Alpha);
+	
+	// node: Diffuse BSDF
+	// type: ShaderNodeBsdfDiffuse
+	float var3_Roughness;
+	var3_Roughness = 0.0;
+	vec3 var4_out_albedo;
+	float var5_out_specular;
+	float var6_out_oren_nayar_roughness;
+	node_bsdf_diffuse(var1_Color, var3_Roughness, var4_out_albedo, var5_out_specular, var6_out_oren_nayar_roughness);
+	
+	ALBEDO = var4_out_albedo;
+	SPECULAR = var5_out_specular;
+	// uncomment it only when you set diffuse mode to oren nayar
+	// ROUGHNESS = oren_nayar_rougness
 }
 "
 
@@ -49,7 +60,7 @@ void fragment() {
 
 resource_name = ""
 shader = SubResource(1)
-shader_param/uni1_ImageTexturetexture_image = ExtResource(1)
+shader_param/uni1_brick_4_diff_1kjpg = ExtResource(1)
 
 [sub_resource id=3 type="ArrayMesh"]
 


### PR DESCRIPTION
1. add comments to provide node information in generated node
2. change `sqrt(roughness)` to `roughness` because blender2.8 changed their shader
3. shorter generated variable name, more readable 
4. fix wrong interpretation of `roughness` of diffuse node, which is Oren Nayar model