### PR TITLE
Assign useful names to BoneAttachment nodes.

### DIFF
--- a/io_scene_godot/converters/armature.py
+++ b/io_scene_godot/converters/armature.py
@@ -6,7 +6,7 @@ from ..structures import NodeTemplate, NodePath, Array
 
 def export_bone_attachment(escn_file, node, parent_gd_node):
     """Export a blender object with parent_bone to a BoneAttachment"""
-    bone_attachment = NodeTemplate('BoneAttachment',
+    bone_attachment = NodeTemplate(node.parent_bone + 'BoneAttachment',
                                    'BoneAttachment', parent_gd_node)
 
     # node.parent_bone is exactly the bone name

--- a/tests/reference_exports/action_with_constraint/bone_attachment_ik.escn
+++ b/tests/reference_exports/action_with_constraint/bone_attachment_ik.escn
@@ -62,34 +62,34 @@ bones/0/parent = -1
 bones/0/rest = Transform(1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0)
 bones/0/pose = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
 bones/0/enabled = true
-bones/0/bound_children = [NodePath("BoneAttachment:")]
+bones/0/bound_children = [NodePath("BoneBoneAttachment:")]
 bones/1/name = "Bone.001"
 bones/1/parent = 0
 bones/1/rest = Transform(0.625552, 0.574117, 0.528275, -0.780182, 0.460328, 0.423572, -1.00583e-07, -0.677117, 0.735875, 0.0, 0.0, -1.0)
 bones/1/pose = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
 bones/1/enabled = true
-bones/1/bound_children = [NodePath("BoneAttachment001:")]
+bones/1/bound_children = [NodePath("Bone001BoneAttachment:")]
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Armature"]
 
 root_node = NodePath("..:")
 anims/ArmatureAction = SubResource(1)
 
-[node name="BoneAttachment" type="BoneAttachment" parent="Armature"]
+[node name="BoneBoneAttachment" type="BoneAttachment" parent="Armature"]
 
 bone_name = "Bone"
 
-[node name="Cube" type="MeshInstance" parent="Armature/BoneAttachment"]
+[node name="Cube" type="MeshInstance" parent="Armature/BoneBoneAttachment"]
 
 mesh = SubResource(2)
 visible = true
 transform = Transform(0.072811, -1.86265e-09, 0.0, -9.31323e-10, 0.186109, -1.58325e-08, 0.0, -2.32831e-09, -0.673504, -3.72529e-09, -5.58794e-09, -0.483741)
 
-[node name="BoneAttachment001" type="BoneAttachment" parent="Armature"]
+[node name="Bone001BoneAttachment" type="BoneAttachment" parent="Armature"]
 
 bone_name = "Bone.001"
 
-[node name="Cube001" type="MeshInstance" parent="Armature/BoneAttachment001"]
+[node name="Cube001" type="MeshInstance" parent="Armature/Bone001BoneAttachment"]
 
 mesh = SubResource(3)
 visible = true

--- a/tests/reference_exports/armature/armature_bone_attachment.escn
+++ b/tests/reference_exports/armature/armature_bone_attachment.escn
@@ -41,7 +41,7 @@ bones/2/parent = 1
 bones/2/rest = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -0.81089)
 bones/2/pose = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
 bones/2/enabled = true
-bones/2/bound_children = [NodePath("BoneAttachment:")]
+bones/2/bound_children = [NodePath("Bone003BoneAttachment:")]
 bones/3/name = "Bone.004"
 bones/3/parent = 2
 bones/3/rest = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -0.81089)
@@ -49,11 +49,11 @@ bones/3/pose = Transform(1.0, 0.0, 0.0, 0.0, 0.99964, -0.0268432, 0.0, 0.0268432
 bones/3/enabled = true
 bones/3/bound_children = []
 
-[node name="BoneAttachment" type="BoneAttachment" parent="Armature"]
+[node name="Bone003BoneAttachment" type="BoneAttachment" parent="Armature"]
 
 bone_name = "Bone.003"
 
-[node name="Cylinder" type="MeshInstance" parent="Armature/BoneAttachment"]
+[node name="Cylinder" type="MeshInstance" parent="Armature/Bone003BoneAttachment"]
 
 mesh = SubResource(1)
 visible = true

--- a/tests/reference_exports/armature/armature_illegal_bone_name.escn
+++ b/tests/reference_exports/armature/armature_illegal_bone_name.escn
@@ -70,18 +70,18 @@ bones/2/parent = 1
 bones/2/rest = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.10021)
 bones/2/pose = Transform(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0)
 bones/2/enabled = true
-bones/2/bound_children = [NodePath("BoneAttachment:")]
+bones/2/bound_children = [NodePath("boneBoneAttachment:")]
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Armature"]
 
 root_node = NodePath("..:")
 anims/ArmatureAction = SubResource(1)
 
-[node name="BoneAttachment" type="BoneAttachment" parent="Armature"]
+[node name="boneBoneAttachment" type="BoneAttachment" parent="Armature"]
 
 bone_name = "bone001"
 
-[node name="attachment" type="MeshInstance" parent="Armature/BoneAttachment"]
+[node name="attachment" type="MeshInstance" parent="Armature/boneBoneAttachment"]
 
 mesh = SubResource(2)
 visible = true


### PR DESCRIPTION
Instead of exporting BoneAttachments with names like `BoneAttachment`,
`BoneAttachment001`, `BoneAttachment002`, and so on, export them with
names like "${BoneName}BoneAttachment".

This makes your Godot code more robust and readable. If I have
attachments to bones named "Hand.L" and "Hand.R", now in Godot I can
refer to them as "HandLBoneAttachment" and "HandRBoneAttachment"
instead of "BoneAttachment" and "BoneAttachment001".