### PR TITLE
Skip copying a texture if the file exists.

### DIFF
--- a/io_scene_godot/converters/material_node_tree/exporters.py
+++ b/io_scene_godot/converters/material_node_tree/exporters.py
@@ -44,7 +44,8 @@ def export_texture(escn_file, export_settings, image):
             src_path = bpy.path.abspath(image.filepath_raw)
         else:
             src_path = image.filepath_raw
-        copyfile(src_path, dst_path)
+        if os.path.abspath(src_path) != os.path.abspath(dst_path):
+            copyfile(src_path, dst_path)
 
     img_resource = ExternalResource(dst_path, "Texture")
     return escn_file.add_external_resource(img_resource, image)


### PR DESCRIPTION
If a file with the same name exists in the export directory, skip
copying it rather than attempting to copy and throwing the error:

```
shutil.SameFileError: '/tmp/example/texture.png' and
'/tmp/example/texture.png' are the same file
```

This error is common if you share a texture among multiple models.

Fixes #182.