### PR TITLE
[WIP] Fix apply modifier export

### DIFF
--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -178,7 +178,11 @@ class MeshResourceExporter:
         self.object.show_only_shape_key = True
         self.object.active_shape_key_index = 0
 
-        mesh = self.object.to_mesh()
+        if apply_modifiers:
+            mesh = self.object.evaluated_get(
+                bpy.context.view_layer.depsgraph).to_mesh()
+        else:
+            mesh = self.object.to_mesh()
 
         self.object.show_only_shape_key = False
 

--- a/io_scene_godot/converters/physics.py
+++ b/io_scene_godot/converters/physics.py
@@ -121,7 +121,7 @@ def generate_convex_mesh_array(escn_file, export_settings, node):
 
     col_shape = InternalResource("ConvexPolygonShape", mesh.name)
 
-    mesh = node.to_mesh()
+    mesh = node.evaluated_get(bpy.context.view_layer.depsgraph).to_mesh()
 
     # Triangulate
     triangulated_mesh = bmesh.new()
@@ -154,7 +154,7 @@ def generate_triangle_mesh_array(escn_file, export_settings, node):
 
     col_shape = InternalResource("ConcavePolygonShape", mesh.name)
 
-    mesh = node.to_mesh()
+    mesh = node.evaluated_get(bpy.context.view_layer.depsgraph).to_mesh()
 
     # Triangulate
     triangulated_mesh = bmesh.new()


### PR DESCRIPTION
Fix `apply modifiers` option due to blender API change

now export mesh with modifiers applied is through `object.evaluated_get(depsgraph).to_mesh()`.

TODO:
1. `bpy.data.meshes.remove` an `evaluated_get` mesh would through `ReferenceError: StructRNA of type Mesh has been removed` (no idea what is it about :(
2. `evaluated_get` also applies armature modifiers, which needs to be turn off