### PR TITLE
Fixing some typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,23 +23,23 @@ This repository includes a Makefile to assist with development. Running
 `make` from the project root will:
 
 1. Export all of the blend files from the `tests/scenes` directory.  
-   If you add a feature, it is suggested that you add a new blend file to 
+   If you add a feature, it is suggested that you add a new blend file to
    the `tests/scenes` directory that uses this feature.
-2. Runs `diff` on the output files conpared to the reference exports. This acts
+2. Runs `diff` on the output files compared to the reference exports. This acts
    as a regression test.
 3. Runs [pycodestyle](http://pycodestyle.pycqa.org/en/latest/) and
    [pylint](https://www.pylint.org/) style tests. Your code must pass these to
    be elegible to merge.
 
 
-Due to differences in blender versions creating minor differences in the 
-output files (even with the same blender release number), the regression tests 
-are best run with blender 2.79 downloaded from 
-[this exact url](http://mirror.cs.umn.edu/blender.org/release/Blender2.79/), 
-which is used for the Travis builds. If you think your blender version is 
-adequate, the hash (visble in the upper right of blender's splash screen) 
-should be `5bd8ac9abfa`. The exporter itself should run on all modern versions 
-of blender, but the output may differ slightly.
+Due to differences in Blender versions creating minor differences in the
+output files (even with the same Blender release number), the regression tests
+are best run with Blender 2.79 downloaded from
+[this exact url](http://mirror.cs.umn.edu/blender.org/release/Blender2.79/),
+which is used for the Travis builds. If you think your Blender version is
+adequate, the hash (visble in the upper right of Blender's splash screen)
+should be `5bd8ac9abfa`. The exporter itself should run on all modern versions
+of Blender, but the output may differ slightly.
 
 
 ## License

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -31,7 +31,7 @@ bl_info = {  # pylint: disable=invalid-name
     "api": 38691,
     "location": "File > Import-Export",
     "description": ("Export Godot Scenes to a format that can be efficiently "
-                    "imported. "),
+                    "imported."),
     "warning": "",
     "wiki_url": ("https://godotengine.org"),
     "tracker_url": "https://github.com/godotengine/blender-exporter",
@@ -91,9 +91,9 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
     use_export_animation = BoolProperty(
         name="Export Animation",
         description="Export all the animation actions (include actions "
-                    "in nla_tracks), note that by default blender animation "
-                    "is exported as actions, so every node would have their "
-                    "own AnimationPlayer hold their actions",
+                    "in nla_tracks), note that by default Blender animation "
+                    "is exported as actions, so every node would have its "
+                    "own AnimationPlayer holding its actions",
         default=True,
     )
     use_mesh_modifiers = BoolProperty(
@@ -113,7 +113,7 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
         default=True,
     )
     use_export_material = BoolProperty(
-        name="Export Materinal",
+        name="Export Material",
         description="Export all the material associated with mesh surfaces",
         default=True,
     )
@@ -124,40 +124,40 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
     )
     generate_external_material = BoolProperty(
         name="Generate External Material",
-        description="If turned on, materials in the exported scene would "
+        description="If turned on, materials in the exported scene will "
                     "generate external .material files when imported to "
-                    "godot,  thus make it easy for material reusing",
+                    "Godot, thus make it easy for material reusing",
         default=False,
     )
     animation_modes = EnumProperty(
         name="Animation Modes",
-        description="Configuration of how blender animation data being "
-                    "exported to godot AnimationPlayer as well as the "
+        description="Configuration of how Blender animation data is "
+                    "exported to Godot AnimationPlayer as well as the "
                     "placement of AnimationPlayers in the node tree.",
         default="ACTIONS",
         items=(
             (
                 "ACTIONS", "Animation as Actions",
-                "Each animated node would have their own AnimationPlayer"
+                "Each animated node will have its own AnimationPlayer"
             ),
             (
                 "SCENE_ANIMATION", "Scene Animation",
-                "All the animations of the whole scene would be placed "
+                "All the animations of the whole scene will be placed "
                 "into one AnimationPlayer at scene root"
             ),
             (
                 "SQUASHED_ACTIONS", "Animation as Actions with Squash",
                 "Animation is exported as actions of nodes, but instead "
                 "of having an individual AnimationPlayer for each node, "
-                "this configuration would squash children nodes' actions "
+                "this configuration will squash children nodes' actions "
                 "to their parents"
             )
         )
     )
     material_search_paths = EnumProperty(
         name="Material Search Paths",
-        description="Search for existing godot materials with names that match"
-                    "the blender material names (ie the file <matname>.tres"
+        description="Search for existing Godot materials with names that match "
+                    "the Blender material names (i.e. the file <matname>.tres "
                     "containing a material resource)",
         default="PROJECT_DIR",
         items=(
@@ -171,7 +171,7 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
             ),
             (
                 "PROJECT_DIR", "Project Directory",
-                "Search for materials in the godot project directory"
+                "Search for materials in the Godot project directory"
             ),
         )
     )

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -52,10 +52,10 @@ def find_godot_project_dir(export_path):
         project_dir = os.path.split(project_dir)[0]
         if project_dir == "/" or project_dir == last:
             raise structures.ValidationError(
-                "Unable to find godot project file"
+                "Unable to find Godot project file"
             )
         last = project_dir
-    logging.info("Found godot project directory at %s", project_dir)
+    logging.info("Found Godot project directory at %s", project_dir)
     return project_dir
 
 
@@ -86,7 +86,7 @@ class GodotExporter:
         deep, this will fail with a recursion error"""
         if node not in self.valid_nodes:
             return
-        logging.info("Exporting Blender Object: %s", node.name)
+        logging.info("Exporting Blender object: %s", node.name)
 
         prev_node = bpy.context.scene.objects.active
         bpy.context.scene.objects.active = node


### PR DESCRIPTION
Some typos in the descriptions for the Blender GUI were fixed. Also the
names `Godot` and `Blender` were capitalized.

Please note: I didn't touch any of the code that does actual work. So I
probably didn't break anything.