### PR TITLE
fixed: material out of range, boolean mod, new: gdscript, gdprim, gdcsg, grease pencil, reexport button

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -23,7 +23,7 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 from .structures import ValidationError
-from .ui_components import GodotTextProps, GodotObProps
+from .ui_components import GodotTextProps, GodotObProps, GodotTopBar, ReExportGodot, set_export_config
 
 bl_info = {  # pylint: disable=invalid-name
     "name": "Godot Engine Exporter",
@@ -196,7 +196,7 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
                 "filter_glob",
                 "xna_validate",
             ))
-
+            set_export_config(self.filepath, keywords)
             from . import export_godot
             return export_godot.save(self, context, **keywords)
         except ValidationError as error:
@@ -215,7 +215,8 @@ def register():
     bpy.types.TOPBAR_MT_file_export.append(menu_func)
     bpy.utils.register_class(GodotTextProps)
     bpy.utils.register_class(GodotObProps)
-
+    bpy.utils.register_class(GodotTopBar)
+    bpy.utils.register_class(ReExportGodot)
 
 def unregister():
     """Remove addon from blender"""
@@ -223,6 +224,8 @@ def unregister():
     bpy.types.TOPBAR_MT_file_export.remove(menu_func)
     bpy.utils.unregister_class(GodotTextProps)
     bpy.utils.unregister_class(GodotObProps)
+    bpy.utils.unregister_class(GodotTopBar)
+    bpy.utils.unregister_class(ReExportGodot)
 
 
 def export(filename, overrides=None):

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -38,6 +38,7 @@ bl_info = {  # pylint: disable=invalid-name
     "category": "Import-Export"
 }
 
+
 class GodotTextProps(bpy.types.Panel):
     bl_label = "Godot"
     bl_idname = "TEXT_PT_GODOT"
@@ -51,7 +52,6 @@ class GodotTextProps(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        ## simple viewing of text custom props, no editing yet ##
         for keyname in context.edit_text.keys():
             if not keyname.startswith('gd'):
                 continue
@@ -60,7 +60,7 @@ class GodotTextProps(bpy.types.Panel):
             if keyname.startswith('gdinclude'):
                 row.label('%s <bpy.data.texts["%s"]>' % (keyname, value))
             elif keyname.startswith('gdpreload'):
-                row.label('%s <%s>' %(keyname, value))
+                row.label('%s <%s>' % (keyname, value))
             elif keyname == 'gdextends':
                 row.label('script extends <%s>' % value)
             else:
@@ -89,16 +89,16 @@ class GodotObProps(bpy.types.Panel):
                 row = layout.row()
                 if keyname == 'gdscript':
                     if value in bpy.data.texts:
-                        row.label('gdscript: <bpy.data.texts["%s"]>' %value)
+                        row.label('gdscript: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('gdscript: ' %value)
+                        row.label('gdscript: ' % value)
                 elif keyname == 'gdvs':
                     if value in bpy.data.texts:
-                        row.label('visual script: <bpy.data.texts["%s"]>' % value)
+                        row.label('vscript: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('visual script: <inline>')
+                        row.label('vscript: <inline>')
                 elif keyname.startswith('gdpreload'):
-                    row.label('%s <%s>' % (keyname, value) )
+                    row.label('%s <%s>' % (keyname, value))
                 elif keyname == 'gdextends':
                     row.label('script extends <%s>' % value)
                 elif keyname.startswith('gdinclude'):
@@ -113,7 +113,7 @@ class GodotObProps(bpy.types.Panel):
                     vname = keyname.strip().split()[-1]
                     if '.' in vname:
                         vname = vname.replace('.', '_')
-                    row.label('%s :%s= %s' % (vname, gtype, value) )
+                    row.label('%s :%s= %s' % (vname, gtype, value))
 
 
 class ExportGodot(bpy.types.Operator, ExportHelper):

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -38,6 +38,106 @@ bl_info = {  # pylint: disable=invalid-name
     "category": "Import-Export"
 }
 
+#@bpy.utils.register_class
+#class GodotSetProp(bpy.types.Operator):
+#    "godot script props"
+#    bl_idname = "godot.new"
+#    bl_label = "new var"
+#    bl_options = {'REGISTER'}
+#    script_name = bpy.props.StringProperty()
+#    script_value = bpy.props.StringProperty()
+#    def invoke(self, context, event):
+#        context.edit_text[self.script_name] = self.script_value
+
+class GodotTextProps(bpy.types.Panel):
+    bl_label = "Godot"
+    bl_idname = "TEXT_PT_GODOT"
+    bl_space_type = 'TEXT_EDITOR'
+    bl_region_type = 'UI'
+    @classmethod
+    def poll(self, context):
+        if context.edit_text:
+            return True
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        #op = row.operator('godot.new', text='extends')
+        #op.script_name = 'gdextends'
+        #op.script_value = 'Spatial'  ## TODO, extends Spatial is already the default
+
+        ## simple viewing of text custom props, no editing yet ##
+        ## blender should support custom attribute in the editor, not sure why thats missing ##
+        for keyname in context.edit_text.keys():
+            if not keyname.startswith('gd'):
+                continue
+            row = layout.row()
+            value = context.edit_text[keyname]
+            if keyname.startswith('gdinclude'):
+                row.label('%s <bpy.data.texts["%s"]>' %(keyname, value))
+            elif keyname.startswith('gdpreload'):
+                row.label('%s <%s>' %(keyname, value))
+            elif keyname == 'gdextends':
+                row.label('script extends <%s>' %value)
+            else:
+                gdtype = ''
+                if ':' in keyname:
+                    gdtype = keyname.split(':')[-1].split('.')[0].strip()
+                vname = keyname.strip().split()[-1]
+                if '.' in vname:
+                    vname = vname.replace('.', '_')
+                row.label('%s :%s= %s' %(vname, gtype, value))
+
+
+class GodotObProps(bpy.types.Panel):
+    bl_label = "Godot"
+    bl_idname = "OBJECT_GODOT_PROPS"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "object"
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+        for keyname in obj.keys():
+            if keyname.startswith('gd'):
+                value = obj[keyname]
+                row = layout.row()
+                if keyname == 'gdscript':
+                    if value in bpy.data.texts:
+                        row.label('gdscript: <bpy.data.texts["%s"]>' %value)
+                    else:
+                        row.label('gdscript: ' %value)
+                elif keyname == 'gdvs':
+                    if value in bpy.data.texts:
+                        row.label('visual script: <bpy.data.texts["%s"]>' %value)
+                    else:
+                        row.label('visual script: %s' %value)
+                elif keyname.startswith('gdinclude'):
+                    if value in bpy.data.texts:
+                        row.label('include: <bpy.data.texts["%s"]>' %value)
+                    else:
+                        row.label('WARN include missing: %s' %value)
+                elif keyname.startswith('gdheader'):
+                    if value in bpy.data.texts:
+                        row.label('include header: <bpy.data.texts["%s"]>' %value)
+                    else:
+                        row.label(value)
+                elif keyname.startswith('gdfooter'):
+                    if value in bpy.data.texts:
+                        row.label('include footer: <bpy.data.texts["%s"]>' %value)
+                    else:
+                        row.label(value)
+                else:
+                    gdtype = ''
+                    if ':' in keyname:
+                        gdtype = keyname.split(':')[-1].split('.')[0].strip()
+                    vname = keyname.strip().split()[-1]
+                    if '.' in vname:
+                        vname = vname.replace('.', '_')
+                    row.label('%s :%s= %s' %(vname, gtype, value))
+
+
 
 class ExportGodot(bpy.types.Operator, ExportHelper):
     """Selection to Godot"""
@@ -210,12 +310,15 @@ def register():
     """Add addon to blender"""
     bpy.utils.register_class(ExportGodot)
     bpy.types.TOPBAR_MT_file_export.append(menu_func)
-
+    bpy.utils.register_class(GodotTextProps)
+    bpy.utils.register_class(GodotObProps)
 
 def unregister():
     """Remove addon from blender"""
     bpy.utils.unregister_class(ExportGodot)
     bpy.types.TOPBAR_MT_file_export.remove(menu_func)
+    bpy.utils.unregister_class(GodotTextProps)
+    bpy.utils.unregister_class(GodotObProps)
 
 
 def export(filename, overrides=None):

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -112,22 +112,16 @@ class GodotObProps(bpy.types.Panel):
                     if value in bpy.data.texts:
                         row.label('visual script: <bpy.data.texts["%s"]>' %value)
                     else:
-                        row.label('visual script: %s' %value)
+                        row.label('visual script: <inline>')
+                elif keyname.startswith('gdpreload'):
+                    row.label('%s <%s>' %(keyname, value))
+                elif keyname == 'gdextends':
+                    row.label('script extends <%s>' %value)
                 elif keyname.startswith('gdinclude'):
                     if value in bpy.data.texts:
                         row.label('include: <bpy.data.texts["%s"]>' %value)
                     else:
                         row.label('WARN include missing: %s' %value)
-                elif keyname.startswith('gdheader'):
-                    if value in bpy.data.texts:
-                        row.label('include header: <bpy.data.texts["%s"]>' %value)
-                    else:
-                        row.label(value)
-                elif keyname.startswith('gdfooter'):
-                    if value in bpy.data.texts:
-                        row.label('include footer: <bpy.data.texts["%s"]>' %value)
-                    else:
-                        row.label(value)
                 else:
                     gdtype = ''
                     if ':' in keyname:

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -23,7 +23,7 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 from .structures import ValidationError
-from .ui_components import GodotTextProps, GodotObProps, GodotTopBar, ReExportGodot, set_export_config
+from .ui_components import GodotTextProps, GodotObProps, GodotTopBar, ReExportGodot, GodotPrim, set_export_config
 
 bl_info = {  # pylint: disable=invalid-name
     "name": "Godot Engine Exporter",
@@ -217,6 +217,7 @@ def register():
     bpy.utils.register_class(GodotObProps)
     bpy.utils.register_class(GodotTopBar)
     bpy.utils.register_class(ReExportGodot)
+    bpy.utils.register_class(GodotPrim)
 
 def unregister():
     """Remove addon from blender"""
@@ -226,6 +227,7 @@ def unregister():
     bpy.utils.unregister_class(GodotObProps)
     bpy.utils.unregister_class(GodotTopBar)
     bpy.utils.unregister_class(ReExportGodot)
+    bpy.utils.unregister_class(GodotPrim)
 
 
 def export(filename, overrides=None):

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -38,17 +38,6 @@ bl_info = {  # pylint: disable=invalid-name
     "category": "Import-Export"
 }
 
-#@bpy.utils.register_class
-#class GodotSetProp(bpy.types.Operator):
-#    "godot script props"
-#    bl_idname = "godot.new"
-#    bl_label = "new var"
-#    bl_options = {'REGISTER'}
-#    script_name = bpy.props.StringProperty()
-#    script_value = bpy.props.StringProperty()
-#    def invoke(self, context, event):
-#        context.edit_text[self.script_name] = self.script_value
-
 class GodotTextProps(bpy.types.Panel):
     bl_label = "Godot"
     bl_idname = "TEXT_PT_GODOT"
@@ -62,23 +51,18 @@ class GodotTextProps(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        #op = row.operator('godot.new', text='extends')
-        #op.script_name = 'gdextends'
-        #op.script_value = 'Spatial'  ## TODO, extends Spatial is already the default
-
         ## simple viewing of text custom props, no editing yet ##
-        ## blender should support custom attribute in the editor, not sure why thats missing ##
         for keyname in context.edit_text.keys():
             if not keyname.startswith('gd'):
                 continue
             row = layout.row()
             value = context.edit_text[keyname]
             if keyname.startswith('gdinclude'):
-                row.label('%s <bpy.data.texts["%s"]>' %(keyname, value))
+                row.label('%s <bpy.data.texts["%s"]>' % (keyname, value))
             elif keyname.startswith('gdpreload'):
                 row.label('%s <%s>' %(keyname, value))
             elif keyname == 'gdextends':
-                row.label('script extends <%s>' %value)
+                row.label('script extends <%s>' % value)
             else:
                 gdtype = ''
                 if ':' in keyname:
@@ -86,7 +70,7 @@ class GodotTextProps(bpy.types.Panel):
                 vname = keyname.strip().split()[-1]
                 if '.' in vname:
                     vname = vname.replace('.', '_')
-                row.label('%s :%s= %s' %(vname, gtype, value))
+                row.label('%s :%s= %s' % (vname, gtype, value))
 
 
 class GodotObProps(bpy.types.Panel):
@@ -110,18 +94,18 @@ class GodotObProps(bpy.types.Panel):
                         row.label('gdscript: ' %value)
                 elif keyname == 'gdvs':
                     if value in bpy.data.texts:
-                        row.label('visual script: <bpy.data.texts["%s"]>' %value)
+                        row.label('visual script: <bpy.data.texts["%s"]>' % value)
                     else:
                         row.label('visual script: <inline>')
                 elif keyname.startswith('gdpreload'):
-                    row.label('%s <%s>' %(keyname, value))
+                    row.label('%s <%s>' % (keyname, value) )
                 elif keyname == 'gdextends':
-                    row.label('script extends <%s>' %value)
+                    row.label('script extends <%s>' % value)
                 elif keyname.startswith('gdinclude'):
                     if value in bpy.data.texts:
-                        row.label('include: <bpy.data.texts["%s"]>' %value)
+                        row.label('include: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('WARN include missing: %s' %value)
+                        row.label('WARN include missing: %s' % value)
                 else:
                     gdtype = ''
                     if ':' in keyname:
@@ -129,8 +113,7 @@ class GodotObProps(bpy.types.Panel):
                     vname = keyname.strip().split()[-1]
                     if '.' in vname:
                         vname = vname.replace('.', '_')
-                    row.label('%s :%s= %s' %(vname, gtype, value))
-
+                    row.label('%s :%s= %s' % (vname, gtype, value) )
 
 
 class ExportGodot(bpy.types.Operator, ExportHelper):
@@ -306,6 +289,7 @@ def register():
     bpy.types.TOPBAR_MT_file_export.append(menu_func)
     bpy.utils.register_class(GodotTextProps)
     bpy.utils.register_class(GodotObProps)
+
 
 def unregister():
     """Remove addon from blender"""

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -58,11 +58,11 @@ class GodotTextProps(bpy.types.Panel):
             row = layout.row()
             value = context.edit_text[keyname]
             if keyname.startswith('gdinclude'):
-                row.label('%s <bpy.data.texts["%s"]>' % (keyname, value))
+                row.label(text='%s <bpy.data.texts["%s"]>' % (keyname, value))
             elif keyname.startswith('gdpreload'):
-                row.label('%s <%s>' % (keyname, value))
+                row.label(text='%s <%s>' % (keyname, value))
             elif keyname == 'gdextends':
-                row.label('script extends <%s>' % value)
+                row.label(text='script extends <%s>' % value)
             else:
                 gdtype = ''
                 if ':' in keyname:
@@ -70,7 +70,7 @@ class GodotTextProps(bpy.types.Panel):
                 vname = keyname.strip().split()[-1]
                 if '.' in vname:
                     vname = vname.replace('.', '_')
-                row.label('%s :%s= %s' % (vname, gtype, value))
+                row.label(text='%s :%s= %s' % (vname, gtype, value))
 
 
 class GodotObProps(bpy.types.Panel):
@@ -89,23 +89,23 @@ class GodotObProps(bpy.types.Panel):
                 row = layout.row()
                 if keyname == 'gdscript':
                     if value in bpy.data.texts:
-                        row.label('gdscript: <bpy.data.texts["%s"]>' % value)
+                        row.label(text='gdscript: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('gdscript: ' % value)
+                        row.label(text='gdscript: ' % value)
                 elif keyname == 'gdvs':
                     if value in bpy.data.texts:
-                        row.label('vscript: <bpy.data.texts["%s"]>' % value)
+                        row.label(text='vscript: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('vscript: <inline>')
+                        row.label(text='vscript: <inline>')
                 elif keyname.startswith('gdpreload'):
                     row.label('%s <%s>' % (keyname, value))
                 elif keyname == 'gdextends':
-                    row.label('script extends <%s>' % value)
+                    row.label(text='script extends <%s>' % value)
                 elif keyname.startswith('gdinclude'):
                     if value in bpy.data.texts:
-                        row.label('include: <bpy.data.texts["%s"]>' % value)
+                        row.label(text='include: <bpy.data.texts["%s"]>' % value)
                     else:
-                        row.label('WARN include missing: %s' % value)
+                        row.label(text='WARN include missing: %s' % value)
                 else:
                     gdtype = ''
                     if ':' in keyname:
@@ -113,7 +113,7 @@ class GodotObProps(bpy.types.Panel):
                     vname = keyname.strip().split()[-1]
                     if '.' in vname:
                         vname = vname.replace('.', '_')
-                    row.label('%s :%s= %s' % (vname, gtype, value))
+                    row.label(text='%s :%s= %s' % (vname, gtype, value))
 
 
 class ExportGodot(bpy.types.Operator, ExportHelper):

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -135,14 +135,16 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
             ("CAMERA", "Camera", ""),
             ("LIGHT", "Light", ""),
             ("ARMATURE", "Armature", ""),
-            ("GEOMETRY", "Geometry", "")
+            ("GEOMETRY", "Geometry", ""),
+            ("GPENCIL", "GreasePencil", "")
         ),
         default={
             "EMPTY",
             "CAMERA",
             "LIGHT",
             "ARMATURE",
-            "GEOMETRY"
+            "GEOMETRY",
+            "GPENCIL"
         },
     )
 

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -23,6 +23,7 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 from .structures import ValidationError
+from .ui_components import GodotTextProps, GodotObProps
 
 bl_info = {  # pylint: disable=invalid-name
     "name": "Godot Engine Exporter",
@@ -37,83 +38,6 @@ bl_info = {  # pylint: disable=invalid-name
     "support": "OFFICIAL",
     "category": "Import-Export"
 }
-
-
-class GodotTextProps(bpy.types.Panel):
-    bl_label = "Godot"
-    bl_idname = "TEXT_PT_GODOT"
-    bl_space_type = 'TEXT_EDITOR'
-    bl_region_type = 'UI'
-    @classmethod
-    def poll(self, context):
-        if context.edit_text:
-            return True
-
-    def draw(self, context):
-        layout = self.layout
-        row = layout.row()
-        for keyname in context.edit_text.keys():
-            if not keyname.startswith('gd'):
-                continue
-            row = layout.row()
-            value = context.edit_text[keyname]
-            if keyname.startswith('gdinclude'):
-                row.label(text='%s <bpy.data.texts["%s"]>' % (keyname, value))
-            elif keyname.startswith('gdpreload'):
-                row.label(text='%s <%s>' % (keyname, value))
-            elif keyname == 'gdextends':
-                row.label(text='script extends <%s>' % value)
-            else:
-                gdtype = ''
-                if ':' in keyname:
-                    gdtype = keyname.split(':')[-1].split('.')[0].strip()
-                vname = keyname.strip().split()[-1]
-                if '.' in vname:
-                    vname = vname.replace('.', '_')
-                row.label(text='%s :%s= %s' % (vname, gtype, value))
-
-
-class GodotObProps(bpy.types.Panel):
-    bl_label = "Godot"
-    bl_idname = "OBJECT_GODOT_PROPS"
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = "object"
-
-    def draw(self, context):
-        layout = self.layout
-        obj = context.object
-        for keyname in obj.keys():
-            if keyname.startswith('gd'):
-                value = obj[keyname]
-                row = layout.row()
-                if keyname == 'gdscript':
-                    if value in bpy.data.texts:
-                        row.label(text='gdscript: <bpy.data.texts["%s"]>' % value)
-                    else:
-                        row.label(text='gdscript: ' % value)
-                elif keyname == 'gdvs':
-                    if value in bpy.data.texts:
-                        row.label(text='vscript: <bpy.data.texts["%s"]>' % value)
-                    else:
-                        row.label(text='vscript: <inline>')
-                elif keyname.startswith('gdpreload'):
-                    row.label('%s <%s>' % (keyname, value))
-                elif keyname == 'gdextends':
-                    row.label(text='script extends <%s>' % value)
-                elif keyname.startswith('gdinclude'):
-                    if value in bpy.data.texts:
-                        row.label(text='include: <bpy.data.texts["%s"]>' % value)
-                    else:
-                        row.label(text='WARN include missing: %s' % value)
-                else:
-                    gdtype = ''
-                    if ':' in keyname:
-                        gdtype = keyname.split(':')[-1].split('.')[0].strip()
-                    vname = keyname.strip().split()[-1]
-                    if '.' in vname:
-                        vname = vname.replace('.', '_')
-                    row.label(text='%s :%s= %s' % (vname, gtype, value))
 
 
 class ExportGodot(bpy.types.Operator, ExportHelper):

--- a/io_scene_godot/converters/__init__.py
+++ b/io_scene_godot/converters/__init__.py
@@ -16,6 +16,7 @@ are stored in individual files.
 """
 
 from .simple_nodes import *  # pylint: disable=wildcard-import
+from .grease import export_grease_node
 from .mesh import export_mesh_node
 from .physics import export_physics_properties
 from .armature import export_armature_node, export_bone_attachment
@@ -32,7 +33,8 @@ BLENDER_TYPE_TO_EXPORTER = {
     "CURVE": export_mesh_node,
     "SURFACE": export_mesh_node,
     "META": export_mesh_node,
-    "FONT": export_mesh_node
+    "FONT": export_mesh_node,
+    "GPENCIL" : export_grease_node
 }
 
 BONE_ATTACHMENT_EXPORTER = export_bone_attachment

--- a/io_scene_godot/converters/animation/serializer.py
+++ b/io_scene_godot/converters/animation/serializer.py
@@ -86,9 +86,7 @@ class TransformFrame:
         # FIXME: lose negative scale
         xform_frame.scale = xform_matrix.to_scale()
 
-        if rotation_mode == 'QUATERNION':
-            xform_frame.rotation_euler = xform_matrix.to_euler()
-        elif rotation_mode == 'AXIS_ANGLE':
+        if rotation_mode in ('QUATERNION', 'AXIS_ANGLE'):
             xform_frame.rotation_euler = xform_matrix.to_euler()
         else:
             xform_frame.rotation_euler = xform_matrix.to_euler(rotation_mode)

--- a/io_scene_godot/converters/animation/serializer.py
+++ b/io_scene_godot/converters/animation/serializer.py
@@ -88,6 +88,8 @@ class TransformFrame:
 
         if rotation_mode == 'QUATERNION':
             xform_frame.rotation_euler = xform_matrix.to_euler()
+        elif rotation_mode == 'AXIS_ANGLE':
+            xform_frame.rotation_euler = xform_matrix.to_euler()
         else:
             xform_frame.rotation_euler = xform_matrix.to_euler(rotation_mode)
         return xform_frame

--- a/io_scene_godot/converters/grease.py
+++ b/io_scene_godot/converters/grease.py
@@ -1,0 +1,356 @@
+"""Exports a grease pencil object"""
+import logging
+import bpy
+import mathutils
+
+from .material import export_material
+from ..structures import (
+    Array, NodeTemplate, InternalResource, Map, gamma_correct)
+from .utils import MeshConverter, MeshResourceKey
+from .physics import has_physics, export_physics_properties
+
+MAX_BONE_PER_VERTEX = 4
+
+def export_grease_node(escn_file, export_settings, obj, parent_gd_node):
+    """Exports a MeshInstance. If the mesh is not already exported, it will
+    trigger the export of that mesh"""
+    # If this mesh object has physics properties, we need to export them first
+    # because they need to be higher in the scene-tree
+
+    if has_physics(obj):
+        parent_gd_node = export_physics_properties(
+            escn_file, export_settings, obj, parent_gd_node
+        )
+        # skip wire mesh which is used as collision mesh
+        if obj.display_type == "WIRE":
+            return parent_gd_node
+
+    mesh_node = NodeTemplate(obj.name, "MeshInstance", parent_gd_node)
+    mesh_exporter = ArrayGreaseResourceExporter(obj)
+    mesh_id = mesh_exporter.export_grease(escn_file, export_settings)
+
+    if mesh_id is not None:
+        mesh_node['mesh'] = "SubResource({})".format(mesh_id)
+        mesh_node['visible'] = obj.visible_get()
+
+        #mesh_resource = escn_file.internal_resources[mesh_id - 1]
+        #export_object_link_material(
+        #    escn_file, export_settings, obj, mesh_resource, mesh_node
+        #)
+
+    # Transform of rigid mesh is moved up to its collision
+    # shapes.
+    if has_physics(obj):
+        mesh_node['transform'] = mathutils.Matrix.Identity(4)
+    else:
+        mesh_node['transform'] = obj.matrix_local
+
+    escn_file.add_node(mesh_node)
+    return mesh_node
+
+
+def fix_vertex(vtx):
+    """Changes a single position vector from y-up to z-up"""
+    return mathutils.Vector((vtx.x, vtx.z, -vtx.y))
+
+
+
+
+class ArrayMeshResource(InternalResource):
+    """Godot ArrayMesh resource, containing surfaces"""
+
+    def __init__(self, name):
+        super().__init__('ArrayMesh', name)
+        self._mat_to_surf_mapping = dict()
+
+    def get_surface_id(self, material_index):
+        """Given blender material index, return the corresponding
+        surface id"""
+        return self._mat_to_surf_mapping.get(material_index, None)
+
+    def set_surface_id(self, material_index, surface_id):
+        """Set a relation between material and surface"""
+        self._mat_to_surf_mapping[material_index] = surface_id
+
+
+class ArrayGreaseResourceExporter:
+    """Export a mesh resource from a blender grease pencil object"""
+
+    def __init__(self, ob):
+        # blender grease pencil object
+        assert ob.type == "GPENCIL"
+        self.object = ob
+        self.mesh_resource = None
+        self.has_tangents = False
+
+    def export_grease(self, escn_file, export_settings):
+        """Saves a mesh into the escn file"""
+        key = MeshResourceKey('ArrayMesh', self.object, export_settings)
+        # Check if mesh resource exists so we don't bother to export it twice,
+        mesh_id = escn_file.get_internal_resource(key)
+        if mesh_id is not None:
+            return mesh_id
+
+        mesh = self.object.data
+
+        if mesh is not None and len(mesh.layers):
+            self.mesh_resource = ArrayMeshResource(mesh.name)
+
+            # Separate by materials into single-material surfaces
+            self.generate_surfaces(
+                escn_file,
+                export_settings,
+                mesh
+            )
+
+            mesh_id = escn_file.add_internal_resource(self.mesh_resource, key)
+            assert mesh_id is not None
+
+        return mesh_id
+
+
+    def generate_surfaces(self, escn_file, export_settings, mesh):
+        """Splits up the mesh into surfaces with a single material each.
+        Within this, it creates the Vertex structure to contain all data about
+        a single vertex
+        """
+        surfaces = []
+        for glayer in mesh.layers:
+            if not len(glayer.frames) or not len(glayer.frames[0].strokes):
+                continue
+
+            for stroke in glayer.frames[0].strokes:
+
+                # Find a surface that matches the material, otherwise create a new
+                # surface for it
+                surface_index = self.mesh_resource.get_surface_id(
+                    stroke.material_index
+                )
+                if surface_index is None:
+                    surface_index = len(surfaces)
+                    self.mesh_resource.set_surface_id(
+                        stroke.material_index, surface_index
+                    )
+                    surface = Surface()
+                    surface.id = surface_index
+                    surfaces.append(surface)
+                    if mesh.materials:
+                        if stroke.material_index >= len(mesh.materials):
+                            print('WARN: bad face.material_index')
+                            mat = mesh.materials[-1]
+                        else:
+                            mat = mesh.materials[stroke.material_index]
+                        if (mat is not None and
+                                export_settings['use_export_material']):
+                            surface.material = export_material(
+                                escn_file,
+                                export_settings,
+                                self.object,
+                                mat
+                            )
+
+                surface = surfaces[surface_index]
+                vertex_indices = []
+
+                for vert_id in range(len(stroke.points)):
+                    vert = stroke.points[vert_id]
+                    new_vert = Vertex( vert )
+
+                    # Merge similar vertices
+                    tup = new_vert.get_tup()
+                    if tup not in surface.vertex_map:
+                        surface.vertex_map[tup] = len(surface.vertex_data.vertices)
+                        surface.vertex_data.vertices.append(new_vert)
+
+                    vertex_index = surface.vertex_map[tup]
+                    surface.vertex_index_map[vert_id] = vertex_index
+
+                    vertex_indices.append(vertex_index)
+
+                if len(vertex_indices) > 2:  # Only triangles and above
+                    surface.vertex_data.indices.append(vertex_indices)
+
+
+
+class VerticesArrays:
+    """Godot use several arrays to store the data of a surface(e.g. vertices,
+    indices, bone weights). A surface object has a single VerticesArrays as its
+    default and also may have a morph array with a list of VerticesArrays"""
+
+    def __init__(self):
+        self.vertices = []
+        self.indices = []
+        self.has_bone = False
+
+    def calc_tangent_dp(self, vert):
+        """Calculates the dot product of the tangent. I think this has
+        something to do with normal mapping"""
+        cross_product = vert.normal.cross(vert.tangent)
+        dot_product = cross_product.dot(vert.bitangent)
+        return 1.0 if dot_product > 0.0 else -1.0
+
+    def get_color_array(self):
+        """Generate a single array that contains the colors of all the vertices
+        in this surface"""
+        has_colors = self.vertices[0].color is not None
+        if has_colors:
+            color_vals = Array("ColorArray(")
+            for vert in self.vertices:
+                col = list(vert.color)
+                if len(col) == 3:
+                    col += [1.0]
+                color_vals.extend(col)
+        else:
+            color_vals = Array("null, ; no Vertex Colors", "", "")
+
+        return color_vals
+
+    def get_tangent_array(self):
+        """Generate a single array that contains the tangents of all the
+        vertices in this surface"""
+        has_tangents = self.vertices[0].tangent is not None
+        if has_tangents:
+            tangent_vals = Array("FloatArray(")
+            for vert in self.vertices:
+                tangent_vals.extend(
+                    list(vert.tangent) + [self.calc_tangent_dp(vert)]
+                )
+        else:
+            tangent_vals = Array("null, ; No Tangents", "", "")
+        return tangent_vals
+
+    def get_uv_array(self, uv_index):
+        """Returns an array representing the specified UV index"""
+        uv_layer_count = len(self.vertices[0].uv)
+        if uv_index >= uv_layer_count:
+            # If lacking 2 UV layers, mark them as null
+            return Array("null, ; No UV%d" % (uv_index+1), "", "")
+
+        uv_vals = Array("Vector2Array(")
+        for vert in self.vertices:
+            uv_vals.extend([
+                vert.uv[uv_index].x,
+                1.0-vert.uv[uv_index].y
+            ])
+
+        return uv_vals
+
+    def generate_lines(self):
+        """Generates the various arrays that are part of the surface (eg
+        normals, position etc.)"""
+        surface_lines = Array(
+            prefix='[\n\t\t', seperator=',\n\t\t', suffix='\n\t]'
+        )
+
+        position_vals = Array("Vector3Array(",
+                              values=[v.vertex for v in self.vertices])
+        normal_vals = Array("Vector3Array(",
+                            values=[v.normal for v in self.vertices])
+
+        surface_lines.append(position_vals.to_string())
+        surface_lines.append(normal_vals.to_string())
+        surface_lines.append(self.get_tangent_array().to_string())
+        surface_lines.append(self.get_color_array().to_string())
+
+        surface_lines.append(self.get_uv_array(0).to_string())
+        surface_lines.append(self.get_uv_array(1).to_string())
+
+
+        # Indices- each face is made of 3 verts, and these are the indices
+        # in the vertex arrays. The backface is computed from the winding
+        # order, hence v[2] before v[1]
+        if self.indices:
+            face_indices = Array(
+                "IntArray(",
+                values=[[v[0], v[2], v[1]] for v in self.indices]
+            )
+        else:
+            # in morph, it has no indices
+            face_indices = Array(
+                "null, ; Morph Object", "", ""
+            )
+
+        surface_lines.append(face_indices.to_string())
+
+        return surface_lines
+
+    def to_string(self):
+        """Serialize"""
+        return self.generate_lines().to_string()
+
+
+class Surface:
+    """A surface is a single part of a mesh (eg in blender, one mesh can have
+    multiple materials. Godot calls these separate parts separate surfaces"""
+
+    def __init__(self):
+        # map from a Vertex.tup() to surface.vertex_data.indices
+        self.vertex_map = dict()
+        self.vertex_data = VerticesArrays()
+        # map from mesh.loop_index to surface.vertex_data.indices
+        self.vertex_index_map = dict()
+        self.id = None
+        self.material = None
+
+    @property
+    def name_str(self):
+        """Used to separate surfaces that are part of the same mesh by their
+        id"""
+        return "surfaces/" + str(self.id)
+
+    def generate_object(self):
+        """Generate object with mapping structure which fully
+        describe the surface"""
+        surface_object = Map()
+        if self.material is not None:
+            surface_object['material'] = self.material
+        #surface_object['primitive'] = 4  # triangles
+        surface_object['primitive'] = 5  # strip
+        surface_object['arrays'] = self.vertex_data
+        return surface_object
+
+    def to_string(self):
+        """Serialize"""
+        return self.generate_object().to_string()
+
+# PRIMITIVE_POINTS = 0 — Render array as points (one vertex equals one point).
+# PRIMITIVE_LINES = 1 — Render array as lines (every two vertices a line is created).
+# PRIMITIVE_LINE_STRIP = 2 — Render array as line strip.
+# PRIMITIVE_LINE_LOOP = 3 — Render array as line loop (like line strip, but closed).
+# PRIMITIVE_TRIANGLES = 4 — Render array as triangles (every three vertices a triangle is created).
+# PRIMITIVE_TRIANGLE_STRIP = 5 — Render array as triangle strips.
+# PRIMITIVE_TRIANGLE_FAN = 6 — Render array as triangle fans.
+
+class Vertex:
+    """Stores all the attributes for a single vertex"""
+
+    def get_tup(self):
+        """Returns a tuple form of this vertex so that it can be hashed"""
+        tup = (self.vertex.x, self.vertex.y, self.vertex.z, self.normal.x,
+               self.normal.y, self.normal.z)
+        for uv_data in self.uv:
+            tup = tup + (uv_data.x, uv_data.y)
+        if self.color is not None:
+            tup = tup + (self.color.x, self.color.y, self.color.z)
+        if self.tangent is not None:
+            tup = tup + (self.tangent.x, self.tangent.y, self.tangent.z)
+        if self.bitangent is not None:
+            tup = tup + (self.bitangent.x, self.bitangent.y,
+                         self.bitangent.z)
+        return tup
+
+    __slots__ = ("vertex", "normal", "tangent", "bitangent", "color", "uv")
+
+    def __init__(self, vert=None):
+        # note: grease pencil vert contains:
+        # 'co', 'pressure', 'rna_type', 'select', 'strength', 'uv_factor', 'uv_rotation'
+        if vert:
+            x,y,z = fix_vertex(vert.co)
+            self.vertex = mathutils.Vector((x, y, z))
+        else:
+            self.vertex = mathutils.Vector((0.0, 0.0, 0.0))
+        self.normal = mathutils.Vector((0.0, 0.0, 0.0))
+        self.tangent = None
+        self.bitangent = None
+        self.color = None
+        self.uv = []

--- a/io_scene_godot/converters/grease.py
+++ b/io_scene_godot/converters/grease.py
@@ -155,20 +155,21 @@ class ArrayGreaseResourceExporter:
                 for vert_id in range(len(stroke.points)):
                     vert = stroke.points[vert_id]
                     new_vert = Vertex( vert )
+                    surface.vertex_data.vertices.append(new_vert)
+                    surface.vertex_data.indices.append(vert_id)
 
                     # Merge similar vertices
-                    tup = new_vert.get_tup()
-                    if tup not in surface.vertex_map:
-                        surface.vertex_map[tup] = len(surface.vertex_data.vertices)
-                        surface.vertex_data.vertices.append(new_vert)
+                    #tup = new_vert.get_tup()
+                    #if tup not in surface.vertex_map:
+                    #    surface.vertex_map[tup] = len(surface.vertex_data.vertices)
+                    #    surface.vertex_data.vertices.append(new_vert)
 
-                    vertex_index = surface.vertex_map[tup]
-                    surface.vertex_index_map[vert_id] = vertex_index
+                    #vertex_index = surface.vertex_map[tup]
+                    #surface.vertex_index_map[vert_id] = vertex_index
+                    #vertex_indices.append(vertex_index)
 
-                    vertex_indices.append(vertex_index)
-
-                if len(vertex_indices) > 2:  # Only triangles and above
-                    surface.vertex_data.indices.append(vertex_indices)
+                #if len(vertex_indices) > 2:  # Only triangles and above
+                #    surface.vertex_data.indices.append(vertex_indices)
 
         for surface in surfaces:
             self.mesh_resource[surface.name_str] = surface
@@ -268,7 +269,8 @@ class VerticesArrays:
         if self.indices:
             face_indices = Array(
                 "IntArray(",
-                values=[[v[0], v[2], v[1]] for v in self.indices]
+                #values=[[v[0], v[2], v[1]] for v in self.indices]
+                flat_values = self.indices
             )
         else:
             # in morph, it has no indices
@@ -311,7 +313,9 @@ class Surface:
         surface_object = Map()
         if self.material is not None:
             surface_object['material'] = self.material
-        surface_object['primitive'] = 5  # triangle strip
+        #surface_object['primitive'] = 5  # triangle strip, sucks with complex shapes
+        #surface_object['primitive'] = 6  # triangle fan, looks better than strip
+        surface_object['primitive'] = 3  # simpler to debug
         surface_object['arrays'] = self.vertex_data
         surface_object['morph_arrays'] = self.morph_arrays
         return surface_object

--- a/io_scene_godot/converters/grease.py
+++ b/io_scene_godot/converters/grease.py
@@ -258,6 +258,9 @@ class VerticesArrays:
         surface_lines.append(self.get_uv_array(0).to_string())
         surface_lines.append(self.get_uv_array(1).to_string())
 
+        surface_lines.append("null, ; No Bones")
+        surface_lines.append("null, ; No Bone Weights")
+
 
         # Indices- each face is made of 3 verts, and these are the indices
         # in the vertex arrays. The backface is computed from the winding
@@ -290,6 +293,7 @@ class Surface:
         # map from a Vertex.tup() to surface.vertex_data.indices
         self.vertex_map = dict()
         self.vertex_data = VerticesArrays()
+        self.morph_arrays = Array(prefix="[", seperator=",\n", suffix="]")
         # map from mesh.loop_index to surface.vertex_data.indices
         self.vertex_index_map = dict()
         self.id = None
@@ -307,9 +311,9 @@ class Surface:
         surface_object = Map()
         if self.material is not None:
             surface_object['material'] = self.material
-        #surface_object['primitive'] = 4  # triangles
-        surface_object['primitive'] = 5  # strip
+        surface_object['primitive'] = 5  # triangle strip
         surface_object['arrays'] = self.vertex_data
+        surface_object['morph_arrays'] = self.morph_arrays
         return surface_object
 
     def to_string(self):

--- a/io_scene_godot/converters/grease.py
+++ b/io_scene_godot/converters/grease.py
@@ -170,6 +170,8 @@ class ArrayGreaseResourceExporter:
                 if len(vertex_indices) > 2:  # Only triangles and above
                     surface.vertex_data.indices.append(vertex_indices)
 
+        for surface in surfaces:
+            self.mesh_resource[surface.name_str] = surface
 
 
 class VerticesArrays:
@@ -244,11 +246,12 @@ class VerticesArrays:
 
         position_vals = Array("Vector3Array(",
                               values=[v.vertex for v in self.vertices])
-        normal_vals = Array("Vector3Array(",
-                            values=[v.normal for v in self.vertices])
+        #normal_vals = Array("Vector3Array(",
+        #                    values=[v.normal for v in self.vertices])
 
         surface_lines.append(position_vals.to_string())
-        surface_lines.append(normal_vals.to_string())
+        #surface_lines.append(normal_vals.to_string())
+        surface_lines.append("null, ; No Normals")
         surface_lines.append(self.get_tangent_array().to_string())
         surface_lines.append(self.get_color_array().to_string())
 

--- a/io_scene_godot/converters/material/material.py
+++ b/io_scene_godot/converters/material/material.py
@@ -68,7 +68,11 @@ def generate_material_resource(escn_file, export_settings, bl_object,
         # to convert material to external file
         material_rsc_name = ''
 
-    if (engine in ('CYCLES', 'BLENDER_EEVEE') and
+    if material.is_grease_pencil:
+        mat = InternalResource("ShaderMaterial", material_rsc_name)
+        mat['albedo_color'] = gamma_correct(material.grease_pencil.fill_color)
+
+    elif (engine in ('CYCLES', 'BLENDER_EEVEE') and
             material.node_tree is not None):
         mat = InternalResource("ShaderMaterial", material_rsc_name)
         try:

--- a/io_scene_godot/converters/material/script_shader/node_converters.py
+++ b/io_scene_godot/converters/material/script_shader/node_converters.py
@@ -761,8 +761,9 @@ class ImageTextureNodeConverter(NodeConverterBase):
         tex_coord = self.in_sockets_map[tex_coord_socket]
         if not tex_coord_socket.is_linked:
             # default to use generated texture coordinates
-            self.flags.aabb_tex_coord_used = True
-            self.local_code.append("%s = %s" % (tex_coord, self.AABB_UVW))
+            #self.flags.aabb_tex_coord_used = True
+            #self.local_code.append("%s = %s" % (tex_coord, self.AABB_UVW))
+            self.local_code.append("%s = vec3（UV, 0.0）" % tex_coord)
 
         tex_var = self.generate_tmp_texture_id(self.bl_node.name)
         if self.bl_node.image is not None:

--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -12,6 +12,10 @@ from .armature import generate_bones_mapping
 from .animation import export_animation_data
 
 MAX_BONE_PER_VERTEX = 4
+PrimMaterialCache = {}
+
+def reset_material_cache():
+    PrimMaterialCache.clear()
 
 # ------------------------------- Prim -----------------------------------
 def export_prim_node(escn_file, export_settings, obj, parent_gd_node):
@@ -58,8 +62,21 @@ def export_prim_node(escn_file, export_settings, obj, parent_gd_node):
 
     mesh_node['mesh'] = "SubResource({})".format(prim_id)
     mesh_node['visible'] = obj.visible_get()
-    mesh_node['material/0'] = None
-    # TODO material
+    gdmat = None
+    if len(obj.data.materials) and obj.data.materials[0]:
+        mat = obj.data.materials[0]
+        if mat in PrimMaterialCache:
+            gdmat = PrimMaterialCache[mat]
+        elif (mat is not None and export_settings['use_export_material']):
+            gdmat = export_material(
+                escn_file,
+                export_settings,
+                obj,
+                mat
+            )
+            PrimMaterialCache[mat] = gdmat
+
+    mesh_node['material/0'] = gdmat
 
     if trans_node is None:
         if has_physics(obj):

--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -605,7 +605,8 @@ class Surface:
         surface_object = Map()
         if self.material is not None:
             surface_object['material'] = self.material
-        surface_object['primitive'] = 4
+        surface_object['primitive'] = 4  # triangles
+        #surface_object['primitive'] = 5  # strip
         surface_object['arrays'] = self.vertex_data
         surface_object['morph_arrays'] = self.morph_arrays
         return surface_object
@@ -614,6 +615,13 @@ class Surface:
         """Serialize"""
         return self.generate_object().to_string()
 
+# PRIMITIVE_POINTS = 0 — Render array as points (one vertex equals one point).
+# PRIMITIVE_LINES = 1 — Render array as lines (every two vertices a line is created).
+# PRIMITIVE_LINE_STRIP = 2 — Render array as line strip.
+# PRIMITIVE_LINE_LOOP = 3 — Render array as line loop (like line strip, but closed).
+# PRIMITIVE_TRIANGLES = 4 — Render array as triangles (every three vertices a triangle is created).
+# PRIMITIVE_TRIANGLE_STRIP = 5 — Render array as triangle strips.
+# PRIMITIVE_TRIANGLE_FAN = 6 — Render array as triangle fans.
 
 class Vertex:
     """Stores all the attributes for a single vertex"""

--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -606,7 +606,6 @@ class Surface:
         if self.material is not None:
             surface_object['material'] = self.material
         surface_object['primitive'] = 4  # triangles
-        #surface_object['primitive'] = 5  # strip
         surface_object['arrays'] = self.vertex_data
         surface_object['morph_arrays'] = self.morph_arrays
         return surface_object

--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -6,7 +6,7 @@ import mathutils
 from .material import export_material
 from ..structures import (
     Array, NodeTemplate, InternalResource, Map, gamma_correct)
-from .utils import MeshConverter, MeshResourceKey
+from .utils import MeshConverter, MeshResourceKey, fix_vertex, gdenums
 from .physics import has_physics, export_physics_properties
 from .armature import generate_bones_mapping
 from .animation import export_animation_data
@@ -38,6 +38,10 @@ def export_prim_node(escn_file, export_settings, obj, parent_gd_node):
         )
         res.append('[sub_resource type="%sMesh" id=%s]' % (prim,prim_id))
 
+    if 'gdprim_radius' in obj.keys() and obj['gdprim_radius']:
+        #TODO *= obj['gdprim_radius']
+        pass
+
     mesh_node = NodeTemplate(obj.name, "MeshInstance", parent_gd_node)
     mesh_node['mesh'] = "SubResource({})".format(prim_id)
     mesh_node['visible'] = obj.visible_get()
@@ -49,11 +53,7 @@ def export_prim_node(escn_file, export_settings, obj, parent_gd_node):
     if has_physics(obj):
         trans = mathutils.Matrix.Identity(4)
     else:
-        trans = obj.matrix_local.copy()
-
-    if 'gdprim_radius' in obj.keys() and obj['gdprim_radius']:
-        #trans *= obj['gdprim_radius']
-        pass
+        trans = obj.matrix_local
 
     mesh_node['transform'] = trans
 
@@ -172,11 +172,6 @@ def export_mesh_node(escn_file, export_settings, obj, parent_gd_node):
             obj.data.shape_keys, 'shapekey')
 
     return mesh_node
-
-
-def fix_vertex(vtx):
-    """Changes a single position vector from y-up to z-up"""
-    return mathutils.Vector((vtx.x, vtx.z, -vtx.y))
 
 
 def get_modifier_armature(mesh_object):

--- a/io_scene_godot/converters/mesh.py
+++ b/io_scene_godot/converters/mesh.py
@@ -278,7 +278,11 @@ class ArrayMeshResourceExporter:
                 surface.id = surface_index
                 surfaces.append(surface)
                 if mesh.materials:
-                    mat = mesh.materials[face.material_index]
+                    if face.material_index >= len(mesh.materials):
+                        print('WARN: bad face.material_index')
+                        mat = mesh.materials[-1]
+                    else:
+                        mat = mesh.materials[face.material_index]
                     if (mat is not None and
                             export_settings['use_export_material']):
                         surface.material = export_material(

--- a/io_scene_godot/converters/physics.py
+++ b/io_scene_godot/converters/physics.py
@@ -245,20 +245,25 @@ def export_physics_controller(escn_file, export_settings, node,
 def export_physics_properties(escn_file, export_settings, node,
                               parent_gd_node):
     """Creates the necessary nodes for the physics"""
-    parent_rbd = get_physics_root(node)
-
-    if parent_rbd is None:
-        parent_gd_node = export_physics_controller(
-            escn_file, export_settings, node, parent_gd_node
+    if 'gdcollide' in node.keys() and node['gdcollide']:
+        return export_collision_shape(
+            escn_file, export_settings, node, physics_gd_node
         )
+    else:
+        parent_rbd = get_physics_root(node)
 
-    # trace the path towards root, find the cloest physics node
-    gd_node_ptr = parent_gd_node
-    while gd_node_ptr.get_type() not in PHYSICS_TYPES:
-        gd_node_ptr = gd_node_ptr.parent
-    physics_gd_node = gd_node_ptr
+        if parent_rbd is None:
+            parent_gd_node = export_physics_controller(
+                escn_file, export_settings, node, parent_gd_node
+            )
 
-    return export_collision_shape(
-        escn_file, export_settings, node, physics_gd_node,
-        parent_override=parent_rbd
-    )
+        # trace the path towards root, find the cloest physics node
+        gd_node_ptr = parent_gd_node
+        while gd_node_ptr.get_type() not in PHYSICS_TYPES:
+            gd_node_ptr = gd_node_ptr.parent
+        physics_gd_node = gd_node_ptr
+
+        return export_collision_shape(
+            escn_file, export_settings, node, physics_gd_node,
+            parent_override=parent_rbd
+        )

--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -85,7 +85,7 @@ class MeshResourceKey:
             print(mesh_data)
             print(gd_rsc_type)
             print(mod_info_list)
-            raise RuntimeError('bad unhashable data in the mod_info_list')
+            raise RuntimeError('unhashable data mod_info_list')
     def __hash__(self):
         return self._hash
 

--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -75,11 +75,17 @@ class MeshResourceKey:
                 # traversal it, however, we cut down it here to allow
                 # some of mesh resource not be shared because of simplicity
                 mod_info_list.append(getattr(modifier, prop))
-
+        if mod_info_list and type(mod_info_list[-1]) is set:
+            mod_info_list.pop()
         self._data = tuple([mesh_data, gd_rsc_type] + mod_info_list)
         # Precalculate the hash now for better efficiency later
-        self._hash = hash(self._data)
-
+        try:
+            self._hash = hash(self._data)
+        except TypeError:
+            print(mesh_data)
+            print(gd_rsc_type)
+            print(mod_info_list)
+            raise RuntimeError('bad unhashable data in the mod_info_list')
     def __hash__(self):
         return self._hash
 

--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -86,6 +86,7 @@ class MeshResourceKey:
             print(gd_rsc_type)
             print(mod_info_list)
             raise RuntimeError('unhashable data mod_info_list')
+
     def __hash__(self):
         return self._hash
 

--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -1,7 +1,20 @@
 """Util functions and structs shared by multiple resource converters"""
+import bpy, bmesh, mathutils
 
-import bpy
-import bmesh
+gdenums = {
+    'PRIMITIVE_POINTS' : 0, # Render array as points (one vertex equals one point).
+    'PRIMITIVE_LINES'  : 1, # Render array as lines (every two vertices a line is created).
+    'PRIMITIVE_LINE_STRIP' : 2, # Render array as line strip.
+    'PRIMITIVE_LINE_LOOP' : 3, # Render array as line loop (like line strip, but closed).
+    'PRIMITIVE_TRIANGLES' : 4, # Render array as triangles (every three vertices a triangle is created).
+    'PRIMITIVE_TRIANGLE_STRIP' : 5, # Render array as triangle strips.
+    'PRIMITIVE_TRIANGLE_FAN' : 6, # Render array as triangle fans.
+}
+
+
+def fix_vertex(vtx):
+    """Changes a single position vector from y-up to z-up"""
+    return mathutils.Vector((vtx.x, vtx.z, -vtx.y))
 
 
 def get_applicable_modifiers(obj, export_settings):

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -90,7 +90,8 @@ class GodotExporter:
         bpy.context.view_layer.objects.active = obj
 
         # Figure out what function will perform the export of this object
-        if obj.type not in converters.BLENDER_TYPE_TO_EXPORTER:
+        if 'gdcsg' in obj.keys() and obj['gdcsg']:
+        elif obj.type not in converters.BLENDER_TYPE_TO_EXPORTER:
             logging.warning(
                 "Unknown object type. Treating as empty: %s", obj.name
             )
@@ -122,13 +123,14 @@ class GodotExporter:
         self.bl_object_gd_node_map[obj] = exported_node
 
         gds = None
+        gdprops = ('gdinclude', 'gdvar', 'gdconst', 'gdfunc', 'gdclass', 'gdenum', 'gdpreload')
         if 'gdscript' in obj.keys():
             comp = ['']
             gdextends = 'Spatial'
             for keyname in obj.keys():
                 if keyname == 'gdextends':
                     gdextends = obj[keyname]
-                elif keyname.startswith(('gdinclude', 'gdvar', 'gdconst', 'gdfunc', 'gdclass', 'gdenum', 'gdpreload')):
+                elif keyname.startswith(gdprops):
                     value = obj[keyname]
                     if keyname.startswith(('gdinclude', 'gdfunc', 'gdclass', 'gdenum')):
                         if value in bpy.data.texts:

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -325,12 +325,13 @@ class GodotExporter:
                         code = bpy.data.texts[gdname].as_string()
                     else:
                         code = gdname
-                    code = code.replace('"', '\\"').strip()
                     if gdi in self.vs_scripts:  ## VisualScript
                         ## clean up json style code
                         if code.startswith('{') and code.endswith('}'):
                             vscfg = self.vs_scripts[gdi]
                             #if 'gdscript' in vscfg:  ## TODO insert call to gdscript
+                            if '\n' not in code:
+                                code = '\n'.join( [ ln+',' for ln in code[:-1].split(', ') ] )
                             subres = [
                                 '[sub_resource type="VisualScript" id=%s]' % gdi,
                                 'data = {',
@@ -351,6 +352,7 @@ class GodotExporter:
                             header.extend(subres)
 
                     else:
+                        code = code.replace('"', '\\"').strip()
                         subres = [
                             '[sub_resource type="GDScript" id=%s]' % gdi,
                             'script/source = "' + code,

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -50,9 +50,6 @@ def find_godot_project_dir(export_path):
     while not os.path.isfile(os.path.join(project_dir, "project.godot")):
         project_dir = os.path.split(project_dir)[0]
         if project_dir in ("/", last):
-            #raise structures.ValidationError(
-            #    "Unable to find Godot project file"
-            #)
             return None
         last = project_dir
     logging.info("Found Godot project directory at %s", project_dir)
@@ -151,19 +148,19 @@ class GodotExporter:
 
                         if keyname.startswith('preload'):
                             if gdtype:
-                                comp.append('var %s:%s = preload("%s")' %(vname, gdtype, value))
+                                comp.append('var %s:%s = preload("%s")' % (vname, gdtype, value))
                             else:
-                                comp.append('var %s := preload("%s")' %(vname, value))
+                                comp.append('var %s := preload("%s")' % (vname, value))
                         elif keyname.startswith( 'var' ):
                             if gdtype:
-                                comp.append('var %s:%s = %s' %(vname, gdtype, value))
+                                comp.append('var %s:%s = %s' % (vname, gdtype, value))
                             else:
-                                comp.append('var %s := %s' %(vname, value))
+                                comp.append('var %s := %s' % (vname, value))
                         elif keyname.startswith( 'const' ):
                             if gdtype:
-                                comp.append('const %s:%s = %s' %(vname, gdtype, value))
+                                comp.append('const %s:%s = %s' % (vname, gdtype, value))
                             else:
-                                comp.append('const %s := %s' %(vname, value))
+                                comp.append('const %s := %s' % (vname, value))
 
             if obj['gdscript'] in bpy.data.texts:
                 code = bpy.data.texts[ obj['gdscript'] ].as_string()
@@ -192,26 +189,13 @@ class GodotExporter:
                     code  # hashable
                 )
                 gdfunc.extend([
-                    '[sub_resource type="GDScript" id=%s]' %gds,
+                    '[sub_resource type="GDScript" id=%s]' % gds,
                     'script/source = "' + code,
                     '"',
                 ])
 
-                ## TODO
-                #vsfunc = []
-                #gvs = self.escn_file.add_internal_resource(
-                #    vsfunc, # item can be a list
-                #    'vs:' + code  # hashable
-                #)
-                #vsfunc.extend([
-                #    '[sub_resource type="VisualScriptFunction" id=%s]' %gvs,
-                #    'resource_name = "_ready"',
-                #    'script = SubResource( %s )' %gds,
-                #])
-
             gds = self.escn_file.get_internal_resource( code )
-            exported_node['script'] = 'SubResource( %s )' %gds
-
+            exported_node['script'] = 'SubResource( %s )' % gds
 
         ## godot visual scripting support ##
         if 'gdvs' in obj.keys():
@@ -473,4 +457,3 @@ def save(operator, context, filepath="", **kwargs):
     logging.getLogger().removeHandler(exporter_log_handler)
 
     return {"FINISHED"}
-

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -90,8 +90,7 @@ class GodotExporter:
         bpy.context.view_layer.objects.active = obj
 
         # Figure out what function will perform the export of this object
-        if 'gdcsg' in obj.keys() and obj['gdcsg']:
-        elif obj.type not in converters.BLENDER_TYPE_TO_EXPORTER:
+        if obj.type not in converters.BLENDER_TYPE_TO_EXPORTER:
             logging.warning(
                 "Unknown object type. Treating as empty: %s", obj.name
             )

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -163,8 +163,7 @@ class GodotExporter:
                                 comp.append('const %s:%s = %s' %(vname, gdtype, value))
                             else:
                                 comp.append('const %s := %s' %(vname, value))
-            if len(comp) > 1:
-                raise RuntimeError(comp)
+
             if obj['gdscript'] in bpy.data.texts:
                 code = bpy.data.texts[ obj['gdscript'] ].as_string()
             else:
@@ -182,7 +181,7 @@ class GodotExporter:
 
             comp.append(code)
             code = '\n'.join(comp)
-
+            code = code.replace('"', '\\"').strip()
 
             if code not in self.gdscripts:
                 self.gdscripts.append( code )
@@ -197,16 +196,17 @@ class GodotExporter:
                     '"',
                 ])
 
-                vsfunc = []
-                gvs = self.escn_file.add_internal_resource(
-                    vsfunc, # item can be a list
-                    'vs:' + code  # hashable
-                )
-                vsfunc.extend([
-                    '[sub_resource type="VisualScriptFunction" id=%s]' %gvs,
-                    'resource_name = "_ready"',
-                    'script = SubResource( %s )' %gds,
-                ])
+                ## TODO
+                #vsfunc = []
+                #gvs = self.escn_file.add_internal_resource(
+                #    vsfunc, # item can be a list
+                #    'vs:' + code  # hashable
+                #)
+                #vsfunc.extend([
+                #    '[sub_resource type="VisualScriptFunction" id=%s]' %gvs,
+                #    'resource_name = "_ready"',
+                #    'script = SubResource( %s )' %gds,
+                #])
 
             gds = self.escn_file.get_internal_resource( code )
             exported_node['script'] = 'SubResource( %s )' %gds

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -50,9 +50,10 @@ def find_godot_project_dir(export_path):
     while not os.path.isfile(os.path.join(project_dir, "project.godot")):
         project_dir = os.path.split(project_dir)[0]
         if project_dir in ("/", last):
-            raise structures.ValidationError(
-                "Unable to find Godot project file"
-            )
+            #raise structures.ValidationError(
+            #    "Unable to find Godot project file"
+            #)
+            return None
         last = project_dir
     logging.info("Found Godot project directory at %s", project_dir)
     return project_dir
@@ -330,12 +331,8 @@ class GodotExporter:
         """According to `project.godot`, determine all new feature supported
         by that godot version"""
         project_dir = ""
-        try:
+        if self.config['project_path_func']:
             project_dir = self.config["project_path_func"]()
-        except structures.ValidationError:
-            project_dir = False
-            logging.warning(
-                "Not export to Godot project dir, disable all beta features.")
 
         # minimal supported version
         conf_versiton = 3

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -341,6 +341,7 @@ class GodotExporter:
 
     def export(self):
         """Begin the export"""
+        converters.mesh.reset_material_cache()
         self.escn_file = structures.ESCNFile(structures.FileEntry(
             "gd_scene",
             collections.OrderedDict((

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -278,12 +278,15 @@ class Array(list):
     Note that the constructor values parameter flattens the list using the
     add_elements method
     """
-    def __init__(self, prefix, seperator=', ', suffix=')', values=()):
+    def __init__(self, prefix, seperator=', ', suffix=')', values=(), flat_values=()):
         self.prefix = prefix
         self.seperator = seperator
         self.suffix = suffix
         super().__init__()
-        self.add_elements(values)
+        if flat_values:
+            self.add_elements_flat(flat_values)
+        else:
+            self.add_elements(values)
 
         self.__str__ = self.to_string
 
@@ -292,6 +295,9 @@ class Array(list):
         list of lists)"""
         for lis in list_of_lists:
             self.extend(lis)
+
+    def add_elements_flat(self, array):
+        self.extend(array)
 
     def to_string(self):
         """Convert the array to serialized form"""

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -80,7 +80,7 @@ class ESCNFile:
         be found"""
         self.internal_resources.append(item)
         index = len(self.internal_resources)
-        if item is not None and not type(item) is list:  ## generated at a later step
+        if item is not None and not type(item) is list:
             item.heading['id'] = index
         return index
 

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -103,7 +103,7 @@ class ESCNFile:
                 if type(e) is str:
                     ires.append(e)
                 if type(e) is list:
-                    ires.extend(e)
+                    ires.append('\n'.join(e))
                 else:
                     ires.append(e.to_string())
         sections = (

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -98,7 +98,7 @@ class ESCNFile:
         """Serializes the file ready to dump out to disk"""
         sections = (
             self.heading.to_string(),
-            '\n\n'.join(self.subheading),
+            '\n'.join(self.subheading),
             '\n\n'.join(i.to_string() for i in self.external_resources),
             '\n\n'.join(e.to_string() for e in self.internal_resources),
             '\n\n'.join(n.to_string() for n in self.nodes)

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -284,7 +284,7 @@ class Array(list):
         self.suffix = suffix
         super().__init__()
         if flat_values:
-            self.add_elements_flat(flat_values)
+            self.extend(flat_values)
         else:
             self.add_elements(values)
 
@@ -295,9 +295,6 @@ class Array(list):
         list of lists)"""
         for lis in list_of_lists:
             self.extend(lis)
-
-    def add_elements_flat(self, array):
-        self.extend(array)
 
     def to_string(self):
         """Convert the array to serialized form"""
@@ -467,14 +464,14 @@ def float_to_string(num):
 def to_string(val):
     """Attempts to convert any object into a string using the conversions
     table, explicit conversion, or falling back to the str() method"""
-    if hasattr(val, "to_string"):
+    if val is None:
+        val = 'null'
+    elif hasattr(val, "to_string"):
         val = val.to_string()
     else:
         converter = CONVERSIONS.get(type(val))
         if converter is not None:
             val = converter(val)
-        elif val is None:
-            val = 'null'
         else:
             val = str(val)
 

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -80,7 +80,8 @@ class ESCNFile:
         be found"""
         self.internal_resources.append(item)
         index = len(self.internal_resources)
-        item.heading['id'] = index
+        if item is not None and not type(item) is list:  ## generated at a later step
+            item.heading['id'] = index
         return index
 
     def add_node(self, item):
@@ -96,11 +97,20 @@ class ESCNFile:
 
     def to_string(self):
         """Serializes the file ready to dump out to disk"""
+        ires = []
+        for e in self.internal_resources:
+            if e is not None:
+                if type(e) is str:
+                    ires.append(e)
+                if type(e) is list:
+                    ires.extend(e)
+                else:
+                    ires.append(e.to_string())
         sections = (
             self.heading.to_string(),
             '\n'.join(self.subheading),
             '\n\n'.join(i.to_string() for i in self.external_resources),
-            '\n\n'.join(e.to_string() for e in self.internal_resources),
+            '\n\n'.join(ires),
             '\n\n'.join(n.to_string() for n in self.nodes)
         )
         return "\n\n".join([s for s in sections if s]) + "\n"

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -31,9 +31,12 @@ class ESCNFile:
         self.nodes = []
         self.internal_resources = []
         self._internal_hashes = {}
-
+        self.subheading = []
         self.external_resources = []
         self._external_hashes = {}
+
+    def add_subheader(self, lst):
+        self.subheading.extend(lst)
 
     def get_external_resource(self, hashable):
         """Searches for existing external resources, and returns their
@@ -95,6 +98,7 @@ class ESCNFile:
         """Serializes the file ready to dump out to disk"""
         sections = (
             self.heading.to_string(),
+            '\n\n'.join(self.subheading),
             '\n\n'.join(i.to_string() for i in self.external_resources),
             '\n\n'.join(e.to_string() for e in self.internal_resources),
             '\n\n'.join(n.to_string() for n in self.nodes)

--- a/io_scene_godot/structures.py
+++ b/io_scene_godot/structures.py
@@ -467,6 +467,8 @@ def to_string(val):
         converter = CONVERSIONS.get(type(val))
         if converter is not None:
             val = converter(val)
+        elif val is None:
+            val = 'null'
         else:
             val = str(val)
 

--- a/io_scene_godot/ui_components.py
+++ b/io_scene_godot/ui_components.py
@@ -1,5 +1,11 @@
 import bpy
 
+LAST_EXPORT = {}
+
+def set_export_config(path, options):
+    LAST_EXPORT['filepath'] = path
+    LAST_EXPORT.update(options)
+
 class GodotTextProps(bpy.types.Panel):
     bl_label = "Godot"
     bl_idname = "TEXT_PT_GODOT"
@@ -75,3 +81,20 @@ class GodotObProps(bpy.types.Panel):
                     if '.' in vname:
                         vname = vname.replace('.', '_')
                     row.label(text='%s :%s= %s' % (vname, gtype, value))
+
+
+class ReExportGodot(bpy.types.Operator):
+    bl_idname = "export_godot.reexport"
+    bl_label = "ReExport"
+    def execute(self, context):
+        print(LAST_EXPORT)
+        from . import export_godot
+        return export_godot.save(self, context, **LAST_EXPORT)
+
+class GodotTopBar(bpy.types.Header):
+    bl_space_type = 'TOPBAR'
+    bl_idname = "GODOT_HT_TOOLS"
+
+    def draw(self, context):
+        if LAST_EXPORT:
+            op = self.layout.operator("export_godot.reexport", text='escn')

--- a/io_scene_godot/ui_components.py
+++ b/io_scene_godot/ui_components.py
@@ -37,7 +37,7 @@ class GodotTextProps(bpy.types.Panel):
                 vname = keyname.strip().split()[-1]
                 if '.' in vname:
                     vname = vname.replace('.', '_')
-                row.label(text='%s :%s= %s' % (vname, gtype, value))
+                row.label(text='%s :%s= %s' % (vname, gdtype, value))
 
 
 class GodotObProps(bpy.types.Panel):
@@ -73,6 +73,10 @@ class GodotObProps(bpy.types.Panel):
                         row.label(text='include: <bpy.data.texts["%s"]>' % value)
                     else:
                         row.label(text='WARN include missing: %s' % value)
+                elif keyname=='gdprim':
+                    row.label(text='prim type: %s' % value)
+                elif keyname=='gdprim_radius':
+                    row.label(text='prim radius: %s' % value)
                 else:
                     gdtype = ''
                     if ':' in keyname:
@@ -80,7 +84,7 @@ class GodotObProps(bpy.types.Panel):
                     vname = keyname.strip().split()[-1]
                     if '.' in vname:
                         vname = vname.replace('.', '_')
-                    row.label(text='%s :%s= %s' % (vname, gtype, value))
+                    row.label(text='%s :%s= %s' % (vname, gdtype, value))
 
 
 class ReExportGodot(bpy.types.Operator):
@@ -91,10 +95,38 @@ class ReExportGodot(bpy.types.Operator):
         from . import export_godot
         return export_godot.save(self, context, **LAST_EXPORT)
 
+class GodotPrim(bpy.types.Operator):
+    bl_idname = "export_godot.new_prim"
+    bl_label = "godot primitive"
+    prim_type = bpy.props.StringProperty(
+        name="godot primitive type",
+        description="godot static primitive.",
+        default='',
+    )
+    prim_radius = 0.5
+    def execute(self, context):
+        op = getattr(bpy.ops.mesh, 'primitive_%s_add' % self.prim_type)
+        if self.prim_type not in ('uv_sphere', 'ico_sphere', 'cylinder'):
+            res = op( size=self.prim_radius*2 )
+        else:
+            res = op( radius=self.prim_radius )
+
+        bpy.context.object['gdprim'] = self.prim_type.split('_')[-1]
+        bpy.context.object['gdprim_radius'] = self.prim_radius
+        return res
+
+
 class GodotTopBar(bpy.types.Header):
     bl_space_type = 'TOPBAR'
     bl_idname = "GODOT_HT_TOOLS"
 
     def draw(self, context):
+        op = self.layout.operator('export_godot.new_prim', text='', icon="MESH_CUBE")
+        op.prim_type = 'cube'
+        op = self.layout.operator('export_godot.new_prim', text='', icon="MESH_ICOSPHERE")
+        op.prim_type = 'ico_sphere'
+        op = self.layout.operator('export_godot.new_prim', text='', icon="MESH_CYLINDER")
+        op.prim_type = 'cylinder'
+
         if LAST_EXPORT:
             op = self.layout.operator("export_godot.reexport", text='escn')

--- a/io_scene_godot/ui_components.py
+++ b/io_scene_godot/ui_components.py
@@ -1,0 +1,77 @@
+import bpy
+
+class GodotTextProps(bpy.types.Panel):
+    bl_label = "Godot"
+    bl_idname = "TEXT_PT_GODOT"
+    bl_space_type = 'TEXT_EDITOR'
+    bl_region_type = 'UI'
+    @classmethod
+    def poll(self, context):
+        if context.edit_text:
+            return True
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        for keyname in context.edit_text.keys():
+            if not keyname.startswith('gd'):
+                continue
+            row = layout.row()
+            value = context.edit_text[keyname]
+            if keyname.startswith('gdinclude'):
+                row.label(text='%s <bpy.data.texts["%s"]>' % (keyname, value))
+            elif keyname.startswith('gdpreload'):
+                row.label(text='%s <%s>' % (keyname, value))
+            elif keyname == 'gdextends':
+                row.label(text='script extends <%s>' % value)
+            else:
+                gdtype = ''
+                if ':' in keyname:
+                    gdtype = keyname.split(':')[-1].split('.')[0].strip()
+                vname = keyname.strip().split()[-1]
+                if '.' in vname:
+                    vname = vname.replace('.', '_')
+                row.label(text='%s :%s= %s' % (vname, gtype, value))
+
+
+class GodotObProps(bpy.types.Panel):
+    bl_label = "Godot"
+    bl_idname = "OBJECT_PT_GODOT_PROPS"
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = "object"
+
+    def draw(self, context):
+        layout = self.layout
+        obj = context.object
+        for keyname in obj.keys():
+            if keyname.startswith('gd'):
+                value = obj[keyname]
+                row = layout.row()
+                if keyname == 'gdscript':
+                    if value in bpy.data.texts:
+                        row.label(text='gdscript: <bpy.data.texts["%s"]>' % value)
+                    else:
+                        row.label(text='gdscript: ' % value)
+                elif keyname == 'gdvs':
+                    if value in bpy.data.texts:
+                        row.label(text='vscript: <bpy.data.texts["%s"]>' % value)
+                    else:
+                        row.label(text='vscript: <inline>')
+                elif keyname.startswith('gdpreload'):
+                    row.label('%s <%s>' % (keyname, value))
+                elif keyname == 'gdextends':
+                    row.label(text='script extends <%s>' % value)
+                elif keyname.startswith('gdinclude'):
+                    if value in bpy.data.texts:
+                        row.label(text='include: <bpy.data.texts["%s"]>' % value)
+                    else:
+                        row.label(text='WARN include missing: %s' % value)
+                else:
+                    gdtype = ''
+                    if ':' in keyname:
+                        gdtype = keyname.split(':')[-1].split('.')[0].strip()
+                    vname = keyname.strip().split()[-1]
+                    if '.' in vname:
+                        vname = vname.replace('.', '_')
+                    row.label(text='%s :%s= %s' % (vname, gtype, value))


### PR DESCRIPTION
for some reason an empty set ends up in the modifiers list.  i have not tested yet with many other modifiers.  i'm running the official blender2.8

there was also some issue with linked materials, i just have it fall back to the last material, but not sure if that is fully correct.