### PR TITLE
Use UV for image texture with no tex coord input

### DIFF
--- a/io_scene_godot/converters/material/script_shader/node_converters.py
+++ b/io_scene_godot/converters/material/script_shader/node_converters.py
@@ -760,9 +760,7 @@ class ImageTextureNodeConverter(NodeConverterBase):
         tex_coord_socket = self.bl_node.inputs[0]
         tex_coord = self.in_sockets_map[tex_coord_socket]
         if not tex_coord_socket.is_linked:
-            # default to use generated texture coordinates
-            self.flags.aabb_tex_coord_used = True
-            self.local_code.append("%s = %s" % (tex_coord, self.AABB_UVW))
+            self.local_code.append("%s = vec3（UV, 0.0）" % tex_coord)
 
         tex_var = self.generate_tmp_texture_id(self.bl_node.name)
         if self.bl_node.image is not None:


### PR DESCRIPTION
Previously when no texture coordinate input for ImageTexture, always
defaults to Blender Generated Coordinates. However, it is not consistent
with Blender's behaviour, which defaults use UV.

Fix #250 and #260 