### PR TITLE
Fixes call to mesh.update in Blender 2.81+

### DIFF
--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -39,8 +39,10 @@ def triangulate_mesh(mesh):
         tri_mesh, faces=tri_mesh.faces, quad_method="ALTERNATE")
     tri_mesh.to_mesh(mesh)
     tri_mesh.free()
-
-    mesh.update(calc_loop_triangles=True)
+    if bpy.app.version[1] > 80:
+        mesh.update()
+    else:
+        mesh.update(calc_loop_triangles=True)
 
 
 class MeshResourceKey:


### PR DESCRIPTION
Flag `calc_loop_triangles` isn't allowed in `mesh.update`: https://docs.blender.org/api/master/bpy.types.Mesh.html#bpy.types.Mesh.update