### PR TITLE
Fix style issues causing CI failure

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -23,6 +23,7 @@ import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
 from .structures import ValidationError
+from . import export_godot
 
 bl_info = {  # pylint: disable=invalid-name
     "name": "Godot Engine Exporter",
@@ -211,7 +212,6 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
                 "xna_validate",
             ))
 
-            from . import export_godot
             return export_godot.save(self, context, **keywords)
         except ValidationError as error:
             self.report({'ERROR'}, str(error))
@@ -269,7 +269,6 @@ def export(filename, overrides=None):
         def __init__(self):
             self.report = print
 
-    from . import export_godot
     export_godot.save(FakeOp(), bpy.context, filename, **default_settings)
 
 

--- a/io_scene_godot/converters/material/script_shader/shader_functions.py
+++ b/io_scene_godot/converters/material/script_shader/shader_functions.py
@@ -467,7 +467,7 @@ void node_math_sqrt_no_clamp(float value1, float value2, out float result) {
 void node_math_absolute_no_clamp(float value1, float value2, out float result) {
     result = abs(value1);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_minimum_no_clamp(float value1, float value2, out float result) {
@@ -485,13 +485,13 @@ void node_math_maximum_no_clamp(float value1, float value2, out float result) {
 void node_math_less_than_no_clamp(float value1, float value2, out float result) {
     result = float(value1 < value2);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_greater_than_no_clamp(float value1, float value2, out float result) {
     result = float(value1 > value2);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_round_no_clamp(float value1, float value2, out float result) {
@@ -557,13 +557,13 @@ void node_math_arccosine_no_clamp(float value1, float value2, out float result) 
     else
         result = acos(value1);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_arctangent_no_clamp(float value1, float value2, out float result) {
     result = atan(value1);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_arctan2_no_clamp(float value1, float value2, out float result) {
@@ -647,7 +647,7 @@ void node_math_less_than_clamp(float value1, float value2, out float result) {
 void node_math_greater_than_clamp(float value1, float value2, out float result) {
     result = clamp(float(value1 > value2), 0.0, 1.0);
 }
-"""),
+"""),  # nopep8
 
     ShaderFunction(code="""
 void node_math_round_clamp(float value1, float value2, out float result) {


### PR DESCRIPTION
For the C code we disable the PEP8 check on the long lines.
An alternative would be to wrap before `out float result`, possibly
with a double indentation.

Fixes:
```
io_scene_godot/converters/material/script_shader/shader_functions.py:467:80: E501 line too long (80 > 79 characters)
io_scene_godot/converters/material/script_shader/shader_functions.py:485:80: E501 line too long (81 > 79 characters)
io_scene_godot/converters/material/script_shader/shader_functions.py:491:80: E501 line too long (84 > 79 characters)
io_scene_godot/converters/material/script_shader/shader_functions.py:554:80: E501 line too long (81 > 79 characters)
io_scene_godot/converters/material/script_shader/shader_functions.py:563:80: E501 line too long (82 > 79 characters)
io_scene_godot/converters/material/script_shader/shader_functions.py:647:80: E501 line too long (81 > 79 characters)
```
```
io_scene_godot/__init__.py:214:12: C0415: Import outside toplevel (%s) (import-outside-toplevel)
io_scene_godot/__init__.py:272:4: C0415: Import outside toplevel (%s) (import-outside-toplevel)
```