### PR TITLE
Fix invalid substitution in MixRgbNodeConverter

### DIFF
--- a/io_scene_godot/converters/material/script_shader/node_converters.py
+++ b/io_scene_godot/converters/material/script_shader/node_converters.py
@@ -718,7 +718,7 @@ class MixRgbNodeConverter(NodeConverterBase):
 
         mix_func = find_function_by_name(rgb_mix_func_name)
         if mix_func is None:
-            # TODO: supportt all the blend types
+            # TODO: support all the blend types
             warning_str = 'blend type %s not supported at %s, fall back to ' \
                 'blend type MIX' % (self.bl_node.blend_type, self.bl_node.name)
             logging.warning(warning_str)
@@ -735,7 +735,7 @@ class MixRgbNodeConverter(NodeConverterBase):
         self.add_function_call(mix_func, in_args, out_args)
 
         if self.bl_node.use_clamp:
-            self.local_code.append("%s = clamp(%s, vec4(0.0), vec4(1.0))")
+            self.local_code.append("%s = clamp(%s, vec4(0.0), vec4(1.0))" % (out_color_id, out_color_id))
 
         self.out_sockets_map[out_color_socket] = out_color_id
 


### PR DESCRIPTION
Tested on `blender2.80` as 2.81 doesn't work yet. But it's relevant to `master` too, so PR'ing here and it should be cherry-picked for 2.80 too.