### PR TITLE
Travis: run regression tests only in 2.81 exporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache:
 matrix:
     include:
         - name: Blender 2.80
-          env: BLENDER_VERSION=2.80
+          env: BLENDER_VERSION=2.80 MAKE_OPTION=export-blends
         - name: Blender 2.81
-          env: BLENDER_VERSION=2.81
+          env: BLENDER_VERSION=2.81 MAKE_OPTION=all
 
 before_install:
     - sudo apt-get update
@@ -26,4 +26,4 @@ install:
     - source .envs
 
 script:
-    - make all BLENDER=$BLENDER_BIN PYLINT='python3 -m pylint'
+    - make ${MAKE_OPTION} BLENDER=$BLENDER_BIN PYLINT='python3 -m pylint'

--- a/io_scene_godot/converters/material/script_shader/node_converters.py
+++ b/io_scene_godot/converters/material/script_shader/node_converters.py
@@ -834,7 +834,7 @@ class MappingNodeConverter(NodeConverterBase):
         # However, starting from Blender2.81, all these inputs are sockets
         # (which means they can be variables), so the computation has to be
         # done at shader runtime.
-        if bpy.app.version <= (2, 80, 0):
+        if bpy.app.version < (2, 81, 0):
             loc_mat = mathutils.Matrix.Translation(self.bl_node.translation)
             rot_mat = self.bl_node.rotation.to_matrix().to_4x4()
             sca_mat = mathutils.Matrix((
@@ -851,9 +851,10 @@ class MappingNodeConverter(NodeConverterBase):
                 transform_mat = loc_mat @ rot_mat @ sca_mat
             elif self.bl_node.vector_type == "NORMAL":
                 # inverse transpose
-                transform_mat = (rot_mat @ sca_mat).inverted_safe().T
+                transform_mat = (
+                    rot_mat @ sca_mat).inverted_safe().transposed()
             else:  # "VECTOR"
-                # no translatio
+                # no translation
                 transform_mat = rot_mat @ sca_mat
             transform_mat = blender_value_to_string(transform_mat)
 


### PR DESCRIPTION
This repo only has reference scenes exported from Blender 2.81.
Therefore, only run smoke test for 2.80 exports and run full
regression tests for 2.81 exports.