### PR TITLE
Fix crash for potential non existent texture images.

### DIFF
--- a/io_scene_godot/converters/material/script_shader/node_tree.py
+++ b/io_scene_godot/converters/material/script_shader/node_tree.py
@@ -429,7 +429,10 @@ def export_texture(escn_file, export_settings, image):
         else:
             src_path = image.filepath_raw
         if os.path.normpath(src_path) != os.path.normpath(dst_path):
-            copyfile(src_path, dst_path)
+            if not os.path.exists(src_path):
+                logging.warning("Texture Image '%s' does not exist!", src_path)
+            else:
+                copyfile(src_path, dst_path)
 
     img_resource = ExternalResource(dst_path, "Texture")
     return escn_file.add_external_resource(img_resource, image)


### PR DESCRIPTION
I ran into an issue where the texture image of a material didn't exist on disc, which resulted in a crash and nothing exported whatsoever. I guess that's not intended behaviour.

Currently logging a warning if that's the case. Let me know if this violates your coding standards.