### PR TITLE
Bugfix for #305

### DIFF
--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -155,7 +155,7 @@ class MeshConverter:
             if triangulate:
                 triangulate_mesh(mesh)
 
-            self.has_tangents = mesh.uv_layers and mesh.polygons
+            self.has_tangents = bool(mesh.uv_layers) and bool(mesh.polygons)
             if calculate_tangents:
                 if self.has_tangents:
                     mesh.calc_tangents()


### PR DESCRIPTION
As long as everything listed in #311 is followed, meshes with shape keys should export correctly 100% of the time now.