### PR TITLE
update pylint dependency for build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Python requirements for development
-pylint==2.3.0
+pylint==2.5.3
 pycodestyle==2.4.0


### PR DESCRIPTION
Hi, 

The build is failing due to `isort` in `pylint`. This PR merely pins `pylint` to the latest version.