### PR TITLE
Clarify warning message for unsupported light.

### DIFF
--- a/io_scene_godot/converters/simple_nodes.py
+++ b/io_scene_godot/converters/simple_nodes.py
@@ -143,7 +143,7 @@ def export_light_node(escn_file, export_settings, node, parent_gd_node):
     else:
         light_node = None
         logging.warning(
-            "Unknown light type. Use Point, Spot or Sun: %s", node.name
+            "%s light is not supported. Use Point, Spot or Sun", node.name
         )
 
     if light_node is not None:


### PR DESCRIPTION
Previously the warning read
"Unknown light type. Use Point, Spot or Sun: Area", which is vague it
looks like Area is part of the supported types.

Fixes #353.