### PR TITLE
Update pylint to 2.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Python requirements for development
-pylint==2.3.0
+pylint==2.5.3
 pycodestyle==2.4.0


### PR DESCRIPTION
This should fix the "Cannot import name 'SortImports' from 'isort'"
issue caused by isort 5.0