### PR TITLE
Check if object has parent instead of checking if parent is None

### DIFF
--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -133,7 +133,7 @@ class GodotExporter:
         # CollisionShape node has different direction in blender
         # and godot, so it has a -90 rotation around X axis,
         # here rotate its children back
-        if (exported_node.parent is not None and
+        if (hasattr(exported_node, "parent") and
                 exported_node.parent.get_type() == 'CollisionShape'):
             exported_node['transform'] = (
                 _AXIS_CORRECT.inverted() @


### PR DESCRIPTION
This fixes an issue I'm facing (trying it on blender 2.90.1)

```
Traceback (most recent call last):
  File "/home/will/.config/blender/2.90/scripts/addons/io_scene_godot/__init__.py", line 215, in execute
    return export_godot.save(self, context, **keywords)
  File "/home/will/.config/blender/2.90/scripts/addons/io_scene_godot/export_godot.py", line 318, in save
    exp.export()
  File "/home/will/.config/blender/2.90/scripts/addons/io_scene_godot/export_godot.py", line 267, in export
    self.export_scene()
  File "/home/will/.config/blender/2.90/scripts/addons/io_scene_godot/export_godot.py", line 211, in export_scene
    self.export_object(obj, root_gd_node)
  File "/home/will/.config/blender/2.90/scripts/addons/io_scene_godot/export_godot.py", line 136, in export_object
    if (exported_node.parent and
AttributeError: 'NoneType' object has no attribute 'parent'


```