### PR TITLE
fix 'struct rna of ExportGodot removed' error

### DIFF
--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -19,10 +19,10 @@ without significant importing (it's the same as Godot's tscn format).
 #
 # ##### END GPL LICENSE BLOCK #####
 
+import logging
 import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
-import logging
 from .structures import ValidationError
 from . import export_godot
 

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -22,6 +22,7 @@ without significant importing (it's the same as Godot's tscn format).
 import bpy
 from bpy.props import StringProperty, BoolProperty, FloatProperty, EnumProperty
 from bpy_extras.io_utils import ExportHelper
+import logging
 from .structures import ValidationError
 from . import export_godot
 

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -228,6 +228,7 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
             if exporter_log_handler:
                 logging.getLogger().removeHandler(exporter_log_handler)
 
+
 def menu_func(self, context):
     """Add to the menu"""
     self.layout.operator(ExportGodot.bl_idname, text="Godot Engine (.escn)")

--- a/io_scene_godot/__init__.py
+++ b/io_scene_godot/__init__.py
@@ -206,6 +206,7 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
 
     def execute(self, context):
         """Begin the export"""
+        exporter_log_handler = export_godot.ExporterLogHandler(self)
         try:
             if not self.filepath:
                 raise Exception("filepath not set")
@@ -218,12 +219,14 @@ class ExportGodot(bpy.types.Operator, ExportHelper):
                 "filter_glob",
                 "xna_validate",
             ))
-
+            logging.getLogger().addHandler(exporter_log_handler)
             return export_godot.save(self, context, **keywords)
         except ValidationError as error:
             self.report({'ERROR'}, str(error))
             return {'CANCELLED'}
-
+        finally:
+            if exporter_log_handler:
+                logging.getLogger().removeHandler(exporter_log_handler)
 
 def menu_func(self, context):
     """Add to the menu"""

--- a/io_scene_godot/export_godot.py
+++ b/io_scene_godot/export_godot.py
@@ -313,8 +313,6 @@ class GodotExporter:
 
 def save(operator, context, filepath="", **kwargs):
     """Begin the export"""
-    exporter_log_handler = ExporterLogHandler(operator)
-    logging.getLogger().addHandler(exporter_log_handler)
 
     object_types = kwargs["object_types"]
     # GEOMETRY isn't an object type so replace it with all valid geometry based
@@ -325,7 +323,5 @@ def save(operator, context, filepath="", **kwargs):
 
     with GodotExporter(filepath, kwargs, operator) as exp:
         exp.export()
-
-    logging.getLogger().removeHandler(exporter_log_handler)
 
     return {"FINISHED"}


### PR DESCRIPTION
If an unexpected error occurred such as key error(for example, an armature modifier's object is None) while exporting, and in next exporting will cause "struct RNA of ExportGodot has been removed" error and will never succeed because different exporter_log_handler is added multiple times but not removed as same times,

If the error 'struct RNA of ExportGodot  has been removed' occurred, the user must reopen Blender to try again,this is very annoying.

So this fix make sure the exporter_log_handler will be correctly removed whenever any error occurred.
