### PR TITLE
Rough update to work with Blender 3.0

### DIFF
--- a/io_scene_godot/converters/utils.py
+++ b/io_scene_godot/converters/utils.py
@@ -40,7 +40,8 @@ def triangulate_ngons(mesh):
     bmesh.ops.triangulate(tri_mesh, faces=ngons, quad_method="ALTERNATE")
     tri_mesh.to_mesh(mesh)
     tri_mesh.free()
-    if bpy.app.version[1] > 80:
+
+    if bpy.app.version[0] > 2 or bpy.app.version[1] > 80:
         mesh.update()
     else:
         mesh.update(calc_loop_triangles=True)


### PR DESCRIPTION
Based on some simple testing of mine with Blender 3.0, things mostly work with the fixing of a version check that no longer works under the assumption that `2.x` are the only available versions.

Aside from that version check, I updated the `io_scene_godot.export` method (used for testing reference exports) to be able to introspect the exporter properties successfully. This does not actually ensure that the reference exports are working correctly: it simply allows an attempted export to "work".

_**Note:** as mentioned above one of the reference exports throws an error upon being loaded by Blender 3 (does not get to the export step) and many exported scenes differ from the current reference (obviously). So the references would need some attention from someone with experience debugging their output._