### PR TITLE
Fix use_inherit_scale deprecation, which is removed in 4.0

### DIFF
--- a/io_scene_godot/converters/animation/animation_data.py
+++ b/io_scene_godot/converters/animation/animation_data.py
@@ -60,7 +60,8 @@ class ObjectAnimationExporter:
             if isinstance(self.blender_object.data, bpy.types.Armature):
                 for rbone in self.blender_object.data.bones:
                     if (rbone.use_inherit_rotation is False or
-                            rbone.use_inherit_scale is False):
+                            rbone.inherit_scale == 'NONE' or 
+                            rbone.inherit_scale == 'NONE_LEGACY'):
                         has_non_inherit_bone = True
                         break
             self.need_baking = (


### PR DESCRIPTION
## List of changes
- Blender officially removed `use_inherit_scale`, so it must be fixed to use `inherit_scale`.

## Note
- https://wiki.blender.org/wiki/Reference/Release_Notes/4.0/Python_API